### PR TITLE
fix: persist site removals as tombstones to block legacy resurrection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,27 @@ The delegate stores:
 - **Known sites**: `delta:known_sites` - list of sites with prefix, name, role, contract key
 - **Site state backups**: `delta:site_state:{prefix}` - full state backup for network resilience
 
+### Known-Sites Tombstone Convention
+
+The `delta:known_sites` `Vec<KnownSiteRecord>` doubles as the persistent
+tombstone store for removed sites. A record with
+`name == TOMBSTONE_NAME_SENTINEL` (`"\0__delta_removed__"`, defined in
+`common/src/state.rs`) is a tombstone, not a real site. Tombstones exist
+to block legacy delegates from resurrecting deleted sites after a page
+refresh.
+
+**Every code path that consumes `KnownSites` responses MUST filter
+tombstones via `KnownSiteRecord::is_tombstone()`** before iterating.
+Forgetting this will leak sentinel entries into the UI and display a
+ghost site named `"\0__delta_removed__"`. `restore_known_sites` has a
+`debug_assert!` that catches this in debug builds.
+
+Tombstones are cleared by `clear_tombstone(prefix)` in `ui/src/state.rs`,
+which must be called by any path that adds a site (`create_new_site`,
+`import_site_key`, `visit_site`) — otherwise a previously-removed prefix
+would be silently filtered out of `restore_known_sites` and the re-add
+would appear to fail.
+
 ## Contract Upgrade / State Migration
 
 ### When Contract WASM Changes

--- a/common/src/state.rs
+++ b/common/src/state.rs
@@ -579,6 +579,11 @@ pub fn is_site_owned(
 }
 
 /// A lightweight record of a known site (stored in delegate for persistence).
+///
+/// Records with `name == TOMBSTONE_NAME_SENTINEL` are tombstones for sites
+/// the user explicitly removed. They are stored alongside real records in
+/// the delegate so that deletions survive a page refresh and cannot be
+/// resurrected by a legacy delegate returning stale data.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KnownSiteRecord {
     pub prefix: String,
@@ -588,6 +593,28 @@ pub struct KnownSiteRecord {
     /// Used to detect contract WASM upgrades and migrate state.
     #[serde(default)]
     pub contract_key_b58: Option<String>,
+}
+
+/// Sentinel value stored in `KnownSiteRecord::name` to mark a record as a
+/// tombstone for a removed site. The NUL prefix guarantees the sentinel
+/// can never collide with a user-supplied site name (UI input strips NULs).
+pub const TOMBSTONE_NAME_SENTINEL: &str = "\u{0000}__delta_removed__";
+
+impl KnownSiteRecord {
+    /// Build a tombstone record for a removed site prefix.
+    pub fn tombstone(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            name: TOMBSTONE_NAME_SENTINEL.to_string(),
+            is_owner: false,
+            contract_key_b58: None,
+        }
+    }
+
+    /// Returns true if this record is a removed-site tombstone.
+    pub fn is_tombstone(&self) -> bool {
+        self.name == TOMBSTONE_NAME_SENTINEL
+    }
 }
 
 /// Requests from the UI to the delegate.
@@ -892,6 +919,42 @@ mod tests {
         let mut tampered = page.clone();
         tampered.order = 10;
         assert!(tampered.verify(1, &owner.verifying_key()).is_err());
+    }
+
+    #[test]
+    fn known_site_record_tombstone_roundtrip() {
+        // The tombstone sentinel must survive a CBOR roundtrip through the
+        // existing KnownSiteRecord schema so that no delegate WASM change
+        // is required to persist removed-site tombstones.
+        let real = KnownSiteRecord {
+            prefix: "abcdef1234".into(),
+            name: "My Site".into(),
+            is_owner: true,
+            contract_key_b58: Some("ck".into()),
+        };
+        let tomb = KnownSiteRecord::tombstone("xyz9876543");
+        assert!(!real.is_tombstone());
+        assert!(tomb.is_tombstone());
+
+        let records = vec![real.clone(), tomb.clone()];
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(&records, &mut buf).unwrap();
+        let decoded: Vec<KnownSiteRecord> = ciborium::de::from_reader(buf.as_slice()).unwrap();
+        assert_eq!(decoded.len(), 2);
+        assert!(!decoded[0].is_tombstone());
+        assert_eq!(decoded[0].prefix, "abcdef1234");
+        assert!(decoded[1].is_tombstone());
+        assert_eq!(decoded[1].prefix, "xyz9876543");
+
+        // A record whose name happens to start with NUL but differs must
+        // NOT be treated as a tombstone.
+        let fake = KnownSiteRecord {
+            prefix: "p".into(),
+            name: "\u{0000}not_removed".into(),
+            is_owner: false,
+            contract_key_b58: None,
+        };
+        assert!(!fake.is_tombstone());
     }
 
     #[test]

--- a/ui/src/freenet_api/delegate.rs
+++ b/ui/src/freenet_api/delegate.rs
@@ -133,8 +133,16 @@ pub fn save_known_sites() {
             contract_key_b58: s.contract_key.map(|ck| ck.encoded_contract_id()),
         })
         .collect();
+    let live_prefixes: std::collections::HashSet<String> = sites.keys().cloned().collect();
     drop(sites);
     for removed_prefix in state::REMOVED_PREFIXES.read().iter() {
+        // Belt and braces: if a prefix is somehow both live and tombstoned
+        // (e.g. add/remove race), never serialize the tombstone — a live
+        // site wins. `clear_tombstone` is the primary defense; this
+        // prevents a persisted contradiction if it is ever bypassed.
+        if live_prefixes.contains(removed_prefix) {
+            continue;
+        }
         records.push(delta_core::KnownSiteRecord::tombstone(removed_prefix));
     }
     let request = delta_core::DelegateRequest::StoreKnownSites { sites: records };
@@ -319,6 +327,11 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                     // merged: a legacy delegate may still hold a removal we
                     // recorded before a delegate upgrade, and the current
                     // delegate holds all removals after this fix ships.
+                    //
+                    // If a tombstone arrives for a prefix that's currently in
+                    // SITES (e.g. added via hash route before known_sites
+                    // loaded), remove it too — the user's intent to delete
+                    // must not be silently ignored.
                     if !tombstones.is_empty() {
                         log(&format!(
                             "Delta: loaded {} tombstone(s) from delegate{}",
@@ -330,6 +343,11 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                                 if !removed.contains(&t.prefix) {
                                     removed.push(t.prefix.clone());
                                 }
+                            }
+                        });
+                        state::SITES.with_mut(|sites| {
+                            for t in &tombstones {
+                                sites.remove(&t.prefix);
                             }
                         });
                     }
@@ -372,12 +390,15 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                             }
                         }
                         let has_real = !real_records.is_empty();
+                        let has_tombstones = !tombstones.is_empty();
                         restore_known_sites(real_records);
-                        // If legacy sites were imported, persist to current
-                        // delegate (including the tombstones we just
-                        // learned about) and mark as authoritative so
-                        // subsequent legacy responses are blocked.
-                        if is_legacy && has_real {
+                        // If legacy contributed ANY state — real records OR
+                        // tombstones — persist to the current delegate so
+                        // the merged view survives a refresh. Without this,
+                        // a legacy delegate holding ONLY tombstones would
+                        // leak those tombstones back out of REMOVED_PREFIXES
+                        // on next load and resurrect removed sites.
+                        if is_legacy && (has_real || has_tombstones) {
                             save_known_sites();
                             *CURRENT_SITES_LOADED.write() = true;
                         }
@@ -584,6 +605,17 @@ fn send_to_delegate_key(request: &delta_core::DelegateRequest, delegate_key: Del
 /// For each site, creates a placeholder entry and sends GET+SUBSCRIBE.
 fn restore_known_sites(records: Vec<delta_core::KnownSiteRecord>) {
     for record in records {
+        // Tombstones must be partitioned out before this call — seeing one
+        // here means a new caller bypassed the partition in
+        // handle_delegate_response and we're about to resurrect a removed
+        // site. Fail loudly in debug builds and skip in release.
+        debug_assert!(
+            !record.is_tombstone(),
+            "tombstone reached restore_known_sites — partition is broken"
+        );
+        if record.is_tombstone() {
+            continue;
+        }
         let prefix = record.prefix.clone();
 
         // Don't restore sites the user explicitly removed

--- a/ui/src/freenet_api/delegate.rs
+++ b/ui/src/freenet_api/delegate.rs
@@ -50,6 +50,17 @@ static CURRENT_SITES_LOADED: GlobalSignal<bool> = GlobalSignal::new(|| false);
 /// Used to resolve race: PublicKey may arrive before KnownSites creates the site entry.
 static OWNER_PREFIXES: GlobalSignal<Vec<String>> = GlobalSignal::new(Vec::new);
 
+/// Whether legacy migration has already been fired. Deferring legacy queries
+/// until the current delegate's KnownSites response arrives guarantees that
+/// a legacy response cannot race ahead of the current one and resurrect
+/// deleted sites.
+static LEGACY_MIGRATION_FIRED: GlobalSignal<bool> = GlobalSignal::new(|| false);
+
+// Tombstones let us persist removed prefixes across refreshes WITHOUT
+// changing the delegate WASM schema — the delegate just stores/returns
+// the Vec<KnownSiteRecord> as-is; the UI interprets sentinel entries via
+// KnownSiteRecord::is_tombstone / KnownSiteRecord::tombstone in delta_core.
+
 /// Register the site delegate with the Freenet node.
 pub fn register_delegate() {
     #[cfg(target_arch = "wasm32")]
@@ -72,11 +83,14 @@ pub fn register_delegate() {
                     Ok(_) => {
                         log("Delta: delegate registered");
                         drop(api);
-                        // Load persisted data
+                        // Load persisted data. Legacy migration is deferred
+                        // until the current delegate's KnownSites response
+                        // arrives (see the KnownSites arm of
+                        // handle_delegate_response) — otherwise a legacy
+                        // response could race ahead and resurrect sites the
+                        // user removed.
                         request_public_key();
                         load_known_sites();
-                        // Try to migrate from legacy delegates
-                        fire_legacy_migration();
                     }
                     Err(e) => log(&format!("Delta: delegate registration failed: {e:?}")),
                 }
@@ -103,9 +117,14 @@ pub fn store_signing_key(key_bytes: &[u8; 32], prefix: Option<&str>) {
 }
 
 /// Save the current known sites list to the delegate for persistence.
+///
+/// Tombstones for removed sites are stored alongside real entries (using a
+/// sentinel name) so that deletions survive a page refresh. Without this,
+/// a legacy delegate responding with old KnownSites could resurrect sites
+/// the user explicitly removed.
 pub fn save_known_sites() {
     let sites = state::SITES.read();
-    let records: Vec<delta_core::KnownSiteRecord> = sites
+    let mut records: Vec<delta_core::KnownSiteRecord> = sites
         .values()
         .map(|s| delta_core::KnownSiteRecord {
             prefix: s.prefix.clone(),
@@ -114,6 +133,10 @@ pub fn save_known_sites() {
             contract_key_b58: s.contract_key.map(|ck| ck.encoded_contract_id()),
         })
         .collect();
+    drop(sites);
+    for removed_prefix in state::REMOVED_PREFIXES.read().iter() {
+        records.push(delta_core::KnownSiteRecord::tombstone(removed_prefix));
+    }
     let request = delta_core::DelegateRequest::StoreKnownSites { sites: records };
     send_delegate_request(&request);
 }
@@ -286,22 +309,59 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                     log("Delta: known sites saved to delegate");
                 }
                 DelegateResponse::KnownSites(records) => {
+                    // Split tombstones out first — they populate
+                    // REMOVED_PREFIXES and must NOT be restored as sites.
+                    let (tombstones, real_records): (Vec<_>, Vec<_>) = records
+                        .into_iter()
+                        .partition(delta_core::KnownSiteRecord::is_tombstone);
+
+                    // Tombstones from either current or legacy delegate are
+                    // merged: a legacy delegate may still hold a removal we
+                    // recorded before a delegate upgrade, and the current
+                    // delegate holds all removals after this fix ships.
+                    if !tombstones.is_empty() {
+                        log(&format!(
+                            "Delta: loaded {} tombstone(s) from delegate{}",
+                            tombstones.len(),
+                            if is_legacy { " (legacy)" } else { "" }
+                        ));
+                        state::REMOVED_PREFIXES.with_mut(|removed| {
+                            for t in &tombstones {
+                                if !removed.contains(&t.prefix) {
+                                    removed.push(t.prefix.clone());
+                                }
+                            }
+                        });
+                    }
+
                     if is_legacy && *CURRENT_SITES_LOADED.read() {
-                        // Current delegate already has sites -- it's the source of
-                        // truth. Ignore legacy to respect site removals.
+                        // Current delegate is the source of truth. Ignore
+                        // legacy real records to respect site removals.
                         log(&format!(
                             "Delta: skipping {} legacy known site(s) (current is authoritative)",
-                            records.len()
+                            real_records.len()
                         ));
                     } else {
                         log(&format!(
                             "Delta: loaded {} known site(s) from delegate{}",
-                            records.len(),
+                            real_records.len(),
                             if is_legacy { " (legacy)" } else { "" }
                         ));
-                        if !is_legacy && !records.is_empty() {
-                            *CURRENT_SITES_LOADED.write() = true;
-                            for r in &records {
+                        if !is_legacy {
+                            // The current delegate has responded. Flip the
+                            // flag whenever it holds ANY state — real
+                            // records OR tombstones — because both signal
+                            // "this user has initialized the current
+                            // delegate, so any absent prefix is a removal,
+                            // not a never-seen site." An empty-empty
+                            // response means the user is pre-migration;
+                            // leave the flag off so legacy migration can
+                            // populate the initial state.
+                            let has_any = !real_records.is_empty() || !tombstones.is_empty();
+                            if has_any {
+                                *CURRENT_SITES_LOADED.write() = true;
+                            }
+                            for r in &real_records {
                                 if r.is_owner {
                                     CURRENT_KEY_PREFIXES.with_mut(|prefixes| {
                                         if !prefixes.contains(&r.prefix) {
@@ -311,15 +371,25 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                                 }
                             }
                         }
-                        let has_records = !records.is_empty();
-                        restore_known_sites(records);
-                        // If legacy sites were imported, persist to current delegate
-                        // and mark as authoritative so subsequent legacy responses
-                        // are blocked (prevents re-adding removed sites)
-                        if is_legacy && has_records {
+                        let has_real = !real_records.is_empty();
+                        restore_known_sites(real_records);
+                        // If legacy sites were imported, persist to current
+                        // delegate (including the tombstones we just
+                        // learned about) and mark as authoritative so
+                        // subsequent legacy responses are blocked.
+                        if is_legacy && has_real {
                             save_known_sites();
                             *CURRENT_SITES_LOADED.write() = true;
                         }
+                    }
+
+                    // Once the current delegate has responded, it is safe
+                    // to query legacy delegates: any legacy KnownSites
+                    // response is now either blocked (CURRENT_SITES_LOADED
+                    // is set) or merged into a fresh migration path.
+                    if !is_legacy && !*LEGACY_MIGRATION_FIRED.read() {
+                        *LEGACY_MIGRATION_FIRED.write() = true;
+                        fire_legacy_migration();
                     }
                 }
                 DelegateResponse::SiteStateStored => {

--- a/ui/src/state.rs
+++ b/ui/src/state.rs
@@ -164,6 +164,21 @@ pub fn rename_site(prefix: &str, new_name: String) {
     }
 }
 
+/// Clear a tombstone for a previously-removed site. Called by any code path
+/// that represents explicit user intent to (re-)add a site with this prefix:
+/// `create_new_site`, `import_site_key`, `visit_site`. Without this, a
+/// persisted tombstone would silently filter the new site out of
+/// `restore_known_sites` and it would appear to "not work".
+///
+/// Note: the caller is responsible for triggering `save_known_sites()` after
+/// inserting the site; that save also re-persists the (shrunk)
+/// REMOVED_PREFIXES list.
+pub fn clear_tombstone(prefix: &str) {
+    REMOVED_PREFIXES.with_mut(|removed| {
+        removed.retain(|p| p != prefix);
+    });
+}
+
 /// Remove a site from the sidebar.
 pub fn remove_site(prefix: &str) {
     REMOVED_PREFIXES.with_mut(|removed| {
@@ -219,6 +234,7 @@ pub fn create_new_site(name: String) {
     let sk_bytes = signing_key.to_bytes();
     crate::freenet_api::delegate::store_signing_key(&sk_bytes, Some(&prefix));
 
+    clear_tombstone(&prefix);
     let site = KnownSite {
         name: name.clone(),
         prefix: prefix.clone(),
@@ -276,6 +292,7 @@ pub fn import_site_key(token: String) -> Result<(), String> {
     let mut owner_bytes = [0u8; 32];
     owner_bytes.copy_from_slice(&export.owner_pubkey);
 
+    clear_tombstone(&prefix);
     let site = KnownSite {
         name,
         prefix: prefix.clone(),
@@ -339,6 +356,7 @@ pub fn visit_site(input: String) {
         return;
     }
 
+    clear_tombstone(&prefix);
     let contract_key = contract_key_from_prefix(&prefix);
 
     let placeholder = KnownSite {


### PR DESCRIPTION
## Problem

Deleted Delta sites re-appeared after a page refresh. User report from Ivvor via Matrix: *"I'm still having trouble with Delta sites coming back, but I have a theory. Are they being restored from legacy delegate stores on refresh sometimes?"*

The theory was correct. Two bugs in `ui/src/freenet_api/delegate.rs` caused this:

1. **Race.** `register_delegate` fired `load_known_sites()` and `fire_legacy_migration()` back-to-back. If a legacy delegate's `KnownSites` response arrived before the current delegate's, the `CURRENT_SITES_LOADED` guard was still false and legacy records restored the deleted sites.

2. **Empty-list gap.** `CURRENT_SITES_LOADED` only flipped on a *non-empty* current-delegate response. If the user had deleted all their sites, the current delegate returned an empty list, the flag stayed off, and any legacy response arriving later would unconditionally restore the deleted sites.

Both bugs were amplified by the more fundamental problem that `REMOVED_PREFIXES` was session-only: even when restoration was blocked within a session, a refresh cleared the set and the next load's legacy response would resurrect the sites again.

## Approach

**Persist removals as tombstone `KnownSiteRecord` entries.** When the user removes a site, `save_known_sites` now includes a tombstone alongside the real records. Tombstones use a NUL-prefixed sentinel in the `name` field (`"\0__delta_removed__"`), which cannot collide with any user-supplied site name (UI input strips NULs).

This requires **zero schema changes and no delegate WASM rebuild** — the delegate just stores and returns the `Vec<KnownSiteRecord>` as-is; the UI interprets sentinel entries. `check-migration` confirms the delegate WASM hash is unchanged because the new const and helpers are dead-code-eliminated from the delegate build.

On load, the `KnownSites` response handler now:
- Partitions the response into real records and tombstones.
- Seeds `REMOVED_PREFIXES` from tombstones (for both current and legacy responses — a legacy delegate may still hold a removal recorded before a delegate upgrade).
- Flips `CURRENT_SITES_LOADED` whenever the current delegate holds **any** state (real records **or** tombstones), so "deleted everything" is treated as authoritative.
- Leaves `CURRENT_SITES_LOADED` **off** when the current delegate returns nothing at all, so legitimate first-time legacy migration still works.

Finally, `fire_legacy_migration()` is deferred until the current delegate's `KnownSites` response is handled, eliminating the race entirely.

`restore_known_sites` and the network GET handler already filter by `REMOVED_PREFIXES`, so no changes were needed there.

## Testing

- **Unit test** `known_site_record_tombstone_roundtrip` in `delta-core` covers the sentinel through a `ciborium` encode/decode roundtrip, with:
  - Real records: `is_tombstone() == false`
  - Tombstone records: `is_tombstone() == true`
  - Negative case: a record whose name happens to start with NUL but differs (`"\0not_removed"`) is NOT treated as a tombstone.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` all pass.
- `cargo make preflight` passes.
- `cargo make check-migration` confirms the delegate WASM hash is unchanged — no migration entry needed.

## Migration notes for existing users

The first refresh after this fix ships will still see any "ghost" sites from the pre-fix buggy state because no tombstones exist yet. Removing them once more will now persist, and subsequent refreshes will not resurrect them.

[AI-assisted - Claude]