### PR TITLE
feat: multi-hop contract WASM migration via legacy_contracts.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ delta/
 ├── ui/               # Dioxus web UI (compiled to WASM)
 ├── published-contract/ # Committed web container WASM + params
 ├── legacy_delegates.toml  # Migration entries for delegate WASM changes
-├── scripts/          # add-migration.sh, sync-wasm.sh
+├── legacy_contracts.toml  # Migration entries for contract WASM changes
+├── scripts/          # add-migration.sh, add-contract-migration.sh, sync-wasm.sh
 └── Makefile.toml     # Build tasks
 ```
 
@@ -107,6 +108,24 @@ The new contract validates all signatures and accepts the state.
 
 This happens automatically - no user action needed.
 
+**Multi-hop migration fallback:** when a restored `KnownSiteRecord`
+has no `contract_key_b58` (legacy delegates from before b82d3bc) or
+when the stored key itself refers to a hash no longer on the network,
+the UI additionally probes every previous contract WASM hash recorded
+in `legacy_contracts.toml`. The first GET that returns non-empty
+state wins, and concurrent probes for the same prefix are cancelled
+so a slower response from an older hash can't overwrite fresh state.
+
+**Recording contract WASM hashes is part of the release process.**
+Any commit that changes `site_contract.wasm` — including an incidental
+rebuild caused by touching `common/`, even if the contract's own
+source is unchanged — must first record the currently-committed
+contract WASM hash via `./scripts/add-contract-migration.sh`. The
+`check-migration.sh` preflight script enforces this by comparing the
+previous git-tracked hash against the entries in
+`legacy_contracts.toml` and refusing to publish if the predecessor
+is missing.
+
 ### Delegate WASM Migration
 
 When `site_delegate.wasm` changes, the delegate key changes and stored secrets (signing keys, known sites) become inaccessible under the old key.
@@ -120,19 +139,24 @@ Migration entries in `legacy_delegates.toml` allow the UI to read from old deleg
 ### Upgrade Workflow
 
 ```bash
-# 1. Record old delegate WASM hash (BEFORE code changes)
+# 1. Record old delegate + contract WASM hashes (BEFORE any code change).
+#    Run whichever applies — delegate-only changes don't need the
+#    contract entry, and vice-versa. Changes to `common/` touch BOTH
+#    WASMs because the contract and delegate both depend on delta-core.
 ./scripts/add-migration.sh V2 "Before adding deleted_pages field"
+./scripts/add-contract-migration.sh C3 "Before adding deleted_pages field"
 
 # 2. Make code changes
 
 # 3. Rebuild WASMs
 ./scripts/sync-wasm.sh
 
-# 4. Build and publish
+# 4. Build and publish (preflight check-migration.sh runs automatically
+#    and refuses to publish if a previous hash was not recorded)
 cargo make publish-delta
 
 # 5. Commit everything
-git add legacy_delegates.toml ui/public/contracts/ common/ contracts/
+git add legacy_delegates.toml legacy_contracts.toml ui/public/contracts/ common/ contracts/
 git commit -m "fix: description with delegate migration"
 git push
 ```

--- a/legacy_contracts.toml
+++ b/legacy_contracts.toml
@@ -1,0 +1,34 @@
+# Legacy Contract Registry
+#
+# Contract WASM hashes shipped by previous Delta releases. When the
+# contract WASM changes (code changes, dependency updates, or incidental
+# rebuilds caused by modifying `common/`), the contract_key of every
+# site changes because contract_key = BLAKE3(BLAKE3(wasm) || params).
+#
+# For sites where `KnownSiteRecord.contract_key_b58` is persisted, the
+# delegate-stored key is authoritative and this list is not consulted.
+# But records restored from pre-b82d3bc delegates, or any other path
+# where the stored key is missing or stale, need a way to find their
+# state on the network. On startup the UI iterates every entry here
+# and issues a migration GET for each, then PUTs whichever state
+# arrives back under the current contract key.
+#
+# Fields:
+#   code_hash    = BLAKE3 hash of the raw contract WASM bytes (hex, 64 chars)
+#
+# To add a new entry:  ./scripts/add-contract-migration.sh VERSION "DESCRIPTION"
+#   Run this BEFORE modifying `common/` or the contract so that the
+#   committed `ui/public/contracts/site_contract.wasm` is still the
+#   old release's WASM when its hash is recorded.
+
+[[entry]]
+version = "C1"
+description = "Pre-tombstone WASM (commit 2e664c3)"
+date = "2026-03-29"
+code_hash = "1188d108180a4143e6e4107b193cb90d5c08644e3830499f46186f141f182e81"
+
+[[entry]]
+version = "C2"
+description = "Pre-V7 WASM (f5ecff5, before per-prefix export signing key)"
+date = "2026-04-09"
+code_hash = "b92da83dae278fcdc237d976ec926ee2fdca20e817662ae8a3aeaf09aaf47fa4"

--- a/legacy_contracts.toml
+++ b/legacy_contracts.toml
@@ -32,3 +32,9 @@ version = "C2"
 description = "Pre-V7 WASM (f5ecff5, before per-prefix export signing key)"
 date = "2026-04-09"
 code_hash = "b92da83dae278fcdc237d976ec926ee2fdca20e817662ae8a3aeaf09aaf47fa4"
+
+[[entry]]
+version = "C3"
+description = "V7 WASM (62fe35b/356e6b6, before reproducible builds)"
+date = "2026-04-12"
+code_hash = "53e3395f42d563e6095e6b21d76d6dbcb9db2fc4068fc6705a353f6f46f48778"

--- a/scripts/add-contract-migration.sh
+++ b/scripts/add-contract-migration.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Record the currently-committed site_contract.wasm BLAKE3 hash into
+# legacy_contracts.toml so that future releases can migrate sites whose
+# state lives under this contract key.
+#
+# Run this BEFORE rebuilding the contract WASM (i.e. before
+# ./scripts/sync-wasm.sh), while ui/public/contracts/site_contract.wasm
+# still holds the old release's bytes. Then make the code change, rebuild,
+# and commit everything together.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML="$REPO_ROOT/legacy_contracts.toml"
+COMMITTED="$REPO_ROOT/ui/public/contracts/site_contract.wasm"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
+[ -f "$COMMITTED" ] || die "Committed contract WASM not found: $COMMITTED"
+
+VERSION="${1:?Usage: add-contract-migration.sh VERSION \"DESCRIPTION\"}"
+DESCRIPTION="${2:?Usage: add-contract-migration.sh VERSION \"DESCRIPTION\"}"
+
+CODE_HASH=$(b3sum "$COMMITTED" | cut -d' ' -f1)
+
+echo "Committed contract WASM: $COMMITTED"
+echo "  code_hash: $CODE_HASH"
+
+if grep -qF "$CODE_HASH" "$TOML"; then
+    echo ""
+    echo "This code_hash is already in $TOML — no action needed."
+    exit 0
+fi
+
+DATE=$(date +%Y-%m-%d)
+cat >> "$TOML" << EOF
+
+[[entry]]
+version = "$VERSION"
+description = "$DESCRIPTION"
+date = "$DATE"
+code_hash = "$CODE_HASH"
+EOF
+
+echo ""
+echo "Added $VERSION to $TOML"
+echo ""
+echo "Next steps:"
+echo "  1. Make your code changes (common/, contracts/, etc)"
+echo "  2. ./scripts/sync-wasm.sh          # rebuild and copy new WASMs"
+echo "  3. cargo test -p delta-ui          # verify build + tests"
+echo "  4. git add legacy_contracts.toml ui/public/contracts/"
+echo "  5. git commit"

--- a/scripts/add-contract-migration.sh
+++ b/scripts/add-contract-migration.sh
@@ -16,14 +16,36 @@ COMMITTED="$REPO_ROOT/ui/public/contracts/site_contract.wasm"
 die() { echo "ERROR: $*" >&2; exit 1; }
 
 command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
+command -v git >/dev/null 2>&1 || die "git not found"
 [ -f "$COMMITTED" ] || die "Committed contract WASM not found: $COMMITTED"
 
 VERSION="${1:?Usage: add-contract-migration.sh VERSION \"DESCRIPTION\"}"
 DESCRIPTION="${2:?Usage: add-contract-migration.sh VERSION \"DESCRIPTION\"}"
 
-CODE_HASH=$(b3sum "$COMMITTED" | cut -d' ' -f1)
+# Always hash the HEAD-tracked WASM, not the working-tree WASM, so that
+# running this script after an accidental `sync-wasm.sh` still records
+# the *predecessor* hash rather than the fresh one. Otherwise a
+# developer who rebuilt before recording would silently leave
+# previous-release users stranded.
+HEAD_HASH=$(git -C "$REPO_ROOT" show HEAD:ui/public/contracts/site_contract.wasm 2>/dev/null | b3sum 2>/dev/null | cut -d' ' -f1 || true)
+WORKTREE_HASH=$(b3sum "$COMMITTED" | cut -d' ' -f1)
 
-echo "Committed contract WASM: $COMMITTED"
+if [ -z "$HEAD_HASH" ]; then
+    die "Could not read HEAD:ui/public/contracts/site_contract.wasm from git. Is this a git repo with the contract tracked?"
+fi
+
+if [ "$HEAD_HASH" != "$WORKTREE_HASH" ]; then
+    echo "WARNING: working-tree contract WASM ($WORKTREE_HASH)"
+    echo "         differs from HEAD's tracked WASM ($HEAD_HASH)."
+    echo ""
+    echo "Recording the HEAD hash (the correct predecessor), not the working-tree hash."
+    echo "If you meant to record the working-tree hash, revert \`ui/public/contracts/site_contract.wasm\`"
+    echo "to HEAD first (git checkout HEAD -- ui/public/contracts/site_contract.wasm) and re-run this script."
+fi
+
+CODE_HASH="$HEAD_HASH"
+
+echo "Predecessor contract WASM (from HEAD): $COMMITTED"
 echo "  code_hash: $CODE_HASH"
 
 if grep -qF "$CODE_HASH" "$TOML"; then

--- a/scripts/check-migration.sh
+++ b/scripts/check-migration.sh
@@ -1,33 +1,38 @@
 #!/bin/bash
 set -euo pipefail
 
-# Checks whether the delegate WASM has changed since the last legacy_delegates.toml
-# entry. If so, a migration entry is required before publishing.
+# Checks whether the delegate or contract WASM has changed since the last
+# legacy_delegates.toml / legacy_contracts.toml entry. If so, a migration
+# entry is required before publishing.
 #
 # Usage: ./scripts/check-migration.sh
 # Exit 0 = safe to publish, Exit 1 = migration entry needed
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TOML="$REPO_ROOT/legacy_delegates.toml"
-COMMITTED="$REPO_ROOT/ui/public/contracts/site_delegate.wasm"
+DELEGATE_TOML="$REPO_ROOT/legacy_delegates.toml"
+CONTRACT_TOML="$REPO_ROOT/legacy_contracts.toml"
+DELEGATE_WASM="$REPO_ROOT/ui/public/contracts/site_delegate.wasm"
+CONTRACT_WASM="$REPO_ROOT/ui/public/contracts/site_contract.wasm"
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
 command -v b3sum >/dev/null 2>&1 || die "b3sum not found. Install with: cargo install b3sum"
-[ -f "$COMMITTED" ] || die "Committed delegate WASM not found: $COMMITTED"
+[ -f "$DELEGATE_WASM" ] || die "Committed delegate WASM not found: $DELEGATE_WASM"
+[ -f "$CONTRACT_WASM" ] || die "Committed contract WASM not found: $CONTRACT_WASM"
 
-CURRENT_HASH=$(b3sum "$COMMITTED" | cut -d' ' -f1)
+# -- Delegate check -----------------------------------------------------------
 
-# Build the delegate from source and compare
+CURRENT_DELEGATE_HASH=$(b3sum "$DELEGATE_WASM" | cut -d' ' -f1)
+
 echo "Building delegate WASM from source..."
 "$REPO_ROOT/scripts/build-wasm.sh" -p site-delegate 2>/dev/null
-BUILT_HASH=$(b3sum "$REPO_ROOT/target/wasm32-unknown-unknown/release/site_delegate.wasm" | cut -d' ' -f1)
+BUILT_DELEGATE_HASH=$(b3sum "$REPO_ROOT/target/wasm32-unknown-unknown/release/site_delegate.wasm" | cut -d' ' -f1)
 
-if [ "$CURRENT_HASH" != "$BUILT_HASH" ]; then
+if [ "$CURRENT_DELEGATE_HASH" != "$BUILT_DELEGATE_HASH" ]; then
     echo ""
     echo "WARNING: Committed delegate WASM is stale!"
-    echo "  committed: $CURRENT_HASH"
-    echo "  built:     $BUILT_HASH"
+    echo "  committed: $CURRENT_DELEGATE_HASH"
+    echo "  built:     $BUILT_DELEGATE_HASH"
     echo ""
     echo "Run ./scripts/sync-wasm.sh to update committed WASMs."
     echo "If the delegate code changed, first run:"
@@ -35,40 +40,92 @@ if [ "$CURRENT_HASH" != "$BUILT_HASH" ]; then
     exit 1
 fi
 
-# Check if current hash is already in legacy_delegates.toml (meaning we
-# haven't changed delegate code since last migration entry - that's fine)
-if grep -qF "$CURRENT_HASH" "$TOML"; then
+if grep -qF "$CURRENT_DELEGATE_HASH" "$DELEGATE_TOML"; then
     echo "Current delegate WASM hash is in legacy_delegates.toml (already migrated)."
-    echo "Safe to publish."
-    exit 0
+else
+    DELEGATE_ENTRY_COUNT=$(grep -c '^\[\[entry\]\]' "$DELEGATE_TOML" 2>/dev/null || echo 0)
+    if [ "$DELEGATE_ENTRY_COUNT" -eq 0 ]; then
+        echo "No legacy delegate entries yet (first deploy)."
+    else
+        LAST_DELEGATE_HASH=$(grep 'code_hash' "$DELEGATE_TOML" | tail -1 | sed 's/.*= *"//' | sed 's/".*//')
+        if [ "$CURRENT_DELEGATE_HASH" = "$LAST_DELEGATE_HASH" ]; then
+            echo "Current delegate WASM matches last delegate migration entry."
+        else
+            echo "Delegate WASM has changed since last migration entry."
+            echo "  current hash: $CURRENT_DELEGATE_HASH"
+            echo "  last entry:   $LAST_DELEGATE_HASH"
+        fi
+    fi
 fi
 
-# Current hash is NOT in legacy_delegates.toml. This is OK only if there
-# are no entries at all (first deploy) or if this is intentionally a new
-# version that hasn't been deployed yet.
+# -- Contract check -----------------------------------------------------------
 
-# Count entries
-ENTRY_COUNT=$(grep -c '^\[\[entry\]\]' "$TOML" 2>/dev/null || echo 0)
+CURRENT_CONTRACT_HASH=$(b3sum "$CONTRACT_WASM" | cut -d' ' -f1)
 
-if [ "$ENTRY_COUNT" -eq 0 ]; then
-    echo "No legacy entries yet (first deploy). Safe to publish."
-    exit 0
-fi
-
-# There are legacy entries but the current hash isn't among them.
-# This is the expected state after adding a migration entry and rebuilding.
-# Verify the PREVIOUS hash (last entry's code_hash) differs from current.
-LAST_HASH=$(grep 'code_hash' "$TOML" | tail -1 | sed 's/.*= *"//' | sed 's/".*//')
-
-if [ "$CURRENT_HASH" = "$LAST_HASH" ]; then
-    echo "Current WASM matches last migration entry. No new migration needed."
-    echo "Safe to publish."
-    exit 0
-fi
-
-echo "Delegate WASM has changed since last migration entry."
-echo "  current hash: $CURRENT_HASH"
-echo "  last entry:   $LAST_HASH"
 echo ""
-echo "Safe to publish (migration entries cover previous versions)."
+echo "Building contract WASM from source..."
+"$REPO_ROOT/scripts/build-wasm.sh" -p site-contract 2>/dev/null
+BUILT_CONTRACT_HASH=$(b3sum "$REPO_ROOT/target/wasm32-unknown-unknown/release/site_contract.wasm" | cut -d' ' -f1)
+
+if [ "$CURRENT_CONTRACT_HASH" != "$BUILT_CONTRACT_HASH" ]; then
+    echo ""
+    echo "WARNING: Committed contract WASM is stale!"
+    echo "  committed: $CURRENT_CONTRACT_HASH"
+    echo "  built:     $BUILT_CONTRACT_HASH"
+    echo ""
+    echo "Run ./scripts/sync-wasm.sh to update committed WASMs."
+    echo "If common/ or the contract source changed, first run:"
+    echo "  ./scripts/add-contract-migration.sh VERSION \"DESCRIPTION\""
+    exit 1
+fi
+
+# The contract check is a strict one-directional rule: if the CURRENT
+# committed hash is NOT in legacy_contracts.toml, then the PREVIOUS
+# committed hash (from git HEAD) must be, i.e. the release that's
+# about to ship recorded its predecessor before rebuilding. We detect
+# the "forgot to record" case by checking whether the previous
+# git-tracked hash of site_contract.wasm is present in the TOML.
+
+CONTRACT_ENTRY_COUNT=$(grep -c '^\[\[entry\]\]' "$CONTRACT_TOML" 2>/dev/null || echo 0)
+
+if [ "$CONTRACT_ENTRY_COUNT" -eq 0 ]; then
+    echo "No legacy contract entries yet (first deploy)."
+    echo ""
+    echo "Safe to publish."
+    exit 0
+fi
+
+if grep -qF "$CURRENT_CONTRACT_HASH" "$CONTRACT_TOML"; then
+    echo "Current contract WASM hash is in legacy_contracts.toml."
+    echo ""
+    echo "Safe to publish."
+    exit 0
+fi
+
+PREVIOUS_CONTRACT_HASH=$(git -C "$REPO_ROOT" show HEAD:ui/public/contracts/site_contract.wasm 2>/dev/null | b3sum 2>/dev/null | cut -d' ' -f1 || true)
+
+if [ -z "$PREVIOUS_CONTRACT_HASH" ]; then
+    echo "Could not determine previous contract WASM hash from git; skipping strict check."
+elif [ "$PREVIOUS_CONTRACT_HASH" = "$CURRENT_CONTRACT_HASH" ]; then
+    echo "Contract WASM unchanged from HEAD."
+elif grep -qF "$PREVIOUS_CONTRACT_HASH" "$CONTRACT_TOML"; then
+    echo "Contract WASM changed; previous hash is recorded in legacy_contracts.toml."
+    echo "  previous: $PREVIOUS_CONTRACT_HASH"
+    echo "  current:  $CURRENT_CONTRACT_HASH"
+else
+    echo ""
+    echo "ERROR: Contract WASM changed but the previous hash is NOT in legacy_contracts.toml"
+    echo "  previous (from HEAD): $PREVIOUS_CONTRACT_HASH"
+    echo "  current (committed):  $CURRENT_CONTRACT_HASH"
+    echo ""
+    echo "Sites created with the previous release will be unable to find their state."
+    echo "Record the previous hash before rebuilding:"
+    echo "  git checkout HEAD -- ui/public/contracts/site_contract.wasm"
+    echo "  ./scripts/add-contract-migration.sh V_N 'DESCRIPTION'"
+    echo "  ./scripts/sync-wasm.sh"
+    exit 1
+fi
+
+echo ""
+echo "Safe to publish."
 exit 0

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -19,9 +19,24 @@ struct LegacyEntry {
     code_hash: String,
 }
 
+#[derive(Deserialize)]
+struct LegacyContracts {
+    #[serde(default)]
+    entry: Vec<LegacyContractEntry>,
+}
+
+#[derive(Deserialize)]
+struct LegacyContractEntry {
+    version: String,
+    description: String,
+    date: String,
+    code_hash: String,
+}
+
 fn main() {
     generate_build_info();
     generate_legacy_delegates();
+    generate_legacy_contracts();
 }
 
 fn generate_build_info() {
@@ -89,6 +104,56 @@ fn generate_legacy_delegates() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("legacy_delegates.rs");
+    let existing = fs::read_to_string(&dest).unwrap_or_default();
+    if existing != code {
+        fs::write(&dest, &code).unwrap();
+    }
+}
+
+fn generate_legacy_contracts() {
+    let toml_path = Path::new("..").join("legacy_contracts.toml");
+    println!("cargo:rerun-if-changed=../legacy_contracts.toml");
+
+    let toml_content = match fs::read_to_string(&toml_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "cargo:warning=legacy_contracts.toml not found ({}), using empty list",
+                e
+            );
+            let out_dir = env::var("OUT_DIR").unwrap();
+            let dest = Path::new(&out_dir).join("legacy_contracts.rs");
+            fs::write(
+                dest,
+                "pub const LEGACY_CONTRACT_HASHES: &[[u8; 32]] = &[];\n",
+            )
+            .unwrap();
+            return;
+        }
+    };
+
+    let parsed: LegacyContracts =
+        toml::from_str(&toml_content).expect("Failed to parse legacy_contracts.toml");
+
+    let mut code = String::new();
+    code.push_str(
+        "// AUTO-GENERATED from legacy_contracts.toml — do not edit.\n\n\
+         pub const LEGACY_CONTRACT_HASHES: &[[u8; 32]] = &[\n",
+    );
+
+    for entry in &parsed.entry {
+        let ch_bytes = hex_to_byte_array(&entry.code_hash, &entry.version, "code_hash");
+        code.push_str(&format!(
+            "    // {}: {} ({})\n",
+            entry.version, entry.description, entry.date
+        ));
+        code.push_str(&format_byte_array(&ch_bytes, "    "));
+    }
+
+    code.push_str("];\n");
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("legacy_contracts.rs");
     let existing = fs::read_to_string(&dest).unwrap_or_default();
     if existing != code {
         fs::write(&dest, &code).unwrap();

--- a/ui/src/freenet_api/delegate.rs
+++ b/ui/src/freenet_api/delegate.rs
@@ -666,11 +666,13 @@ fn restore_known_sites(records: Vec<delta_core::KnownSiteRecord>) {
             sites.insert(prefix.clone(), site);
         });
 
-        // Always GET the current contract key. Whichever response
-        // arrives first — current key, stored-but-stale key, or any
-        // legacy-hash probe — wins, and the others are cancelled by
-        // `clear_pending_migrations_for_prefix` once migration
-        // completes.
+        // Enter the initial-capture window for this prefix. Until one
+        // non-empty GET response arrives, every incoming response is
+        // treated as a candidate; the first wins and siblings are
+        // dropped via `finalize_prefix_capture`.
+        super::operations::mark_prefix_migrating(&prefix);
+
+        // Always GET the current contract key.
         super::operations::get_site(&new_contract_key);
 
         // If the delegate persisted a stale `contract_key_b58`, probe
@@ -682,20 +684,18 @@ fn restore_known_sites(records: Vec<delta_core::KnownSiteRecord>) {
             }
         }
 
-        // Probe every historical contract WASM hash from
-        // `legacy_contracts.toml`. Runs unconditionally because:
-        //   - For records with no stored key (legacy delegates from
-        //     before `contract_key_b58` was added), this is the only
-        //     path to find on-network state.
-        //   - For records whose stored key is stale, the stored key
-        //     may itself be from a release that has since been
-        //     superseded on the network; a further-back hash may
-        //     still have data.
-        //   - For records already up-to-date, the filter inside
-        //     `legacy_contract_ids_for_prefix` drops the current key
-        //     from the probe set, so this is a no-op after the
-        //     filter.
-        super::operations::fire_legacy_contract_migrations(&prefix, &new_key_b58);
+        // Only fire the generic legacy-hash sweep when the stored
+        // contract key is either absent or demonstrably stale. In the
+        // steady state where the delegate-persisted
+        // `contract_key_b58` matches the current WASM, there is no
+        // release-era before the current one whose state could live
+        // on the network under this prefix — the site was created
+        // under the current contract WASM. Skipping the sweep avoids
+        // a startup thundering herd: N sites × M legacy hashes of
+        // redundant GETs that will all NotFound.
+        if old_key_b58.is_none() || stored_key_is_stale {
+            super::operations::fire_legacy_contract_migrations(&prefix, &new_key_b58);
+        }
     }
 
     // Replay any pending hash navigation (from deep link)

--- a/ui/src/freenet_api/delegate.rs
+++ b/ui/src/freenet_api/delegate.rs
@@ -643,12 +643,11 @@ fn restore_known_sites(records: Vec<delta_core::KnownSiteRecord>) {
 
         let new_contract_key = state::contract_key_from_prefix(&prefix);
 
-        // Check if WASM upgrade happened (stored key differs from computed key)
         let old_key_b58 = record.contract_key_b58.clone();
         let new_key_b58 = new_contract_key.encoded_contract_id();
-        let needs_migration = old_key_b58.as_ref().is_some_and(|old| *old != new_key_b58);
+        let stored_key_is_stale = old_key_b58.as_ref().is_some_and(|old| *old != new_key_b58);
 
-        if needs_migration {
+        if stored_key_is_stale {
             log(&format!(
                 "Delta: contract WASM upgrade detected for site {prefix}, migrating state"
             ));
@@ -667,26 +666,36 @@ fn restore_known_sites(records: Vec<delta_core::KnownSiteRecord>) {
             sites.insert(prefix.clone(), site);
         });
 
-        if needs_migration {
-            if let Some(old_b58) = old_key_b58 {
-                super::operations::get_for_migration(&old_b58, &prefix);
+        // Always GET the current contract key. Whichever response
+        // arrives first — current key, stored-but-stale key, or any
+        // legacy-hash probe — wins, and the others are cancelled by
+        // `clear_pending_migrations_for_prefix` once migration
+        // completes.
+        super::operations::get_site(&new_contract_key);
+
+        // If the delegate persisted a stale `contract_key_b58`, probe
+        // that specific key in addition to the generic legacy-hash
+        // sweep: the user's state most likely lives there.
+        if stored_key_is_stale {
+            if let Some(old_b58) = old_key_b58.as_deref() {
+                super::operations::get_for_migration(old_b58, &prefix);
             }
-        } else if old_key_b58.is_none() {
-            // No stored key - this is either a fresh site or pre-upgrade.
-            // Try both the current key and the old WASM key (one-time migration).
-            let old_b58 = super::operations::old_contract_id_for_prefix(&prefix);
-            if old_b58 != new_key_b58 {
-                log(&format!(
-                    "Delta: trying one-time migration from old WASM for site {prefix}"
-                ));
-                super::operations::get_for_migration(&old_b58, &prefix);
-            }
-            // Also GET from current key in case it already has state
-            super::operations::get_site(&new_contract_key);
-        } else {
-            // Stored key matches current - normal GET
-            super::operations::get_site(&new_contract_key);
         }
+
+        // Probe every historical contract WASM hash from
+        // `legacy_contracts.toml`. Runs unconditionally because:
+        //   - For records with no stored key (legacy delegates from
+        //     before `contract_key_b58` was added), this is the only
+        //     path to find on-network state.
+        //   - For records whose stored key is stale, the stored key
+        //     may itself be from a release that has since been
+        //     superseded on the network; a further-back hash may
+        //     still have data.
+        //   - For records already up-to-date, the filter inside
+        //     `legacy_contract_ids_for_prefix` drops the current key
+        //     from the probe set, so this is a no-op after the
+        //     filter.
+        super::operations::fire_legacy_contract_migrations(&prefix, &new_key_b58);
     }
 
     // Replay any pending hash navigation (from deep link)

--- a/ui/src/freenet_api/operations.rs
+++ b/ui/src/freenet_api/operations.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::state::{self, KnownSite, SiteRole};
 use dioxus::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Site contract WASM (embedded at build time).
 const SITE_CONTRACT_WASM: &[u8] = include_bytes!("../../public/contracts/site_contract.wasm");
@@ -35,6 +35,89 @@ include!(concat!(env!("OUT_DIR"), "/legacy_contracts.rs"));
 static PENDING_MIGRATIONS: GlobalSignal<BTreeMap<String, String>> =
     GlobalSignal::new(BTreeMap::new);
 
+/// Prefixes whose initial state capture is in progress.
+///
+/// Populated by `restore_known_sites` for each site it is restoring,
+/// and cleared the first time a GET response arrives with non-empty
+/// state for that prefix. While a prefix is in this set, ANY
+/// subsequent non-empty state response for the same prefix — migration
+/// or current-key — is dropped, so a late arrival from an older hash
+/// cannot overwrite state just captured from a newer source.
+///
+/// Once a prefix has been captured (or the user edits/adds a site
+/// outside the startup path), it leaves this set and `handle_site_state`
+/// behaves normally: subsequent `UpdateNotification` state pushes
+/// from the network are accepted for live update.
+static MIGRATING_PREFIXES: GlobalSignal<BTreeSet<String>> = GlobalSignal::new(BTreeSet::new);
+
+/// Register a prefix as "currently being captured from the network".
+/// Called by `restore_known_sites` before firing any GETs for it.
+pub fn mark_prefix_migrating(prefix: &str) {
+    MIGRATING_PREFIXES.with_mut(|set| {
+        set.insert(prefix.to_string());
+    });
+}
+
+/// True iff the given prefix is currently in its initial-capture
+/// window (see `MIGRATING_PREFIXES`).
+fn is_prefix_migrating(prefix: &str) -> bool {
+    MIGRATING_PREFIXES.read().contains(prefix)
+}
+
+/// Classification of an incoming GET response as determined by the
+/// (prefix, key, pending-migrations, migrating-prefixes) tuple. Exposed
+/// for unit testing the state machine in isolation from Dioxus signals
+/// and the WebSocket runtime.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum GetClassification {
+    /// GET for a legacy/migration key that is currently pending. The
+    /// caller should process the state (if non-empty), PUT-migrate it
+    /// to the current key, cancel sibling probes for the prefix, and
+    /// remove this prefix from `MIGRATING_PREFIXES`.
+    PendingMigration { prefix: String },
+    /// GET for the current contract key belonging to a prefix that is
+    /// still being captured. The caller should process the state (if
+    /// non-empty), cancel sibling legacy probes for the prefix, and
+    /// remove the prefix from `MIGRATING_PREFIXES`. No migration PUT
+    /// is needed because the state is already under the current key.
+    InitialCurrentKey { prefix: String },
+    /// GET for a prefix that has already completed its initial capture
+    /// (or was never in the migration window). The response should be
+    /// treated as a live update — processed only if non-empty, no
+    /// migration bookkeeping.
+    LiveUpdate,
+    /// GET for a key we do not recognize at all (pending-migrations
+    /// lookup missed and the prefix cannot be resolved from the key).
+    /// Fall through to the delegate-backup path on NotFound; otherwise
+    /// treat as a live update.
+    Unknown,
+}
+
+/// Pure classifier used by `handle_contract_response::GetResponse`.
+/// Takes the key and three reads of global state so it can be tested
+/// with mocked inputs.
+pub(crate) fn classify_get_response(
+    key_b58: &str,
+    pending_migrations: &BTreeMap<String, String>,
+    migrating_prefixes: &BTreeSet<String>,
+    prefix_for_current_key: Option<&str>,
+) -> GetClassification {
+    if let Some(prefix) = pending_migrations.get(key_b58) {
+        return GetClassification::PendingMigration {
+            prefix: prefix.clone(),
+        };
+    }
+    match prefix_for_current_key {
+        Some(prefix) if migrating_prefixes.contains(prefix) => {
+            GetClassification::InitialCurrentKey {
+                prefix: prefix.to_string(),
+            }
+        }
+        Some(_) => GetClassification::LiveUpdate,
+        None => GetClassification::Unknown,
+    }
+}
+
 /// Handle an incoming response from the Freenet node.
 pub fn handle_response(response: HostResponse) {
     match response {
@@ -57,43 +140,80 @@ fn handle_contract_response(response: ContractResponse) {
             let key_b58 = key.encoded_contract_id();
             log(&format!("Delta: GET response for {key}"));
 
-            // Check if this is a migration GET (old key)
-            let migration_prefix = PENDING_MIGRATIONS.write().remove(&key_b58);
+            let prefix_for_key = find_prefix_for_contract_key(&key);
+            let classification = classify_get_response(
+                &key_b58,
+                &PENDING_MIGRATIONS.read(),
+                &MIGRATING_PREFIXES.read(),
+                prefix_for_key.as_deref(),
+            );
 
             let state_bytes = state.to_vec();
-            if let Some(prefix) = &migration_prefix {
-                if !state_bytes.is_empty() {
-                    // Migration: PUT state to new contract key.
+            match classification {
+                GetClassification::PendingMigration { prefix } => {
+                    // Clear this one entry up front so the classifier
+                    // doesn't re-fire for the same key on a duplicate
+                    // delivery. Sibling probes for the same prefix are
+                    // cleared below on success.
+                    PENDING_MIGRATIONS.write().remove(&key_b58);
+
+                    if state_bytes.is_empty() {
+                        log(&format!(
+                            "Delta: migration GET returned empty for site {prefix}"
+                        ));
+                        return;
+                    }
+                    if !is_prefix_migrating(&prefix) {
+                        // Some other probe already captured fresh
+                        // state for this prefix and removed it from
+                        // the migrating set. Drop the late arrival —
+                        // it would otherwise last-write-wins clobber
+                        // whatever we already captured.
+                        log(&format!(
+                            "Delta: dropping late migration response for {prefix} \
+                             (prefix already captured)"
+                        ));
+                        return;
+                    }
                     log(&format!(
                         "Delta: migrating state for site {prefix} from old key to new key"
                     ));
-                    let new_key = state::contract_key_from_prefix(prefix);
+                    let new_key = state::contract_key_from_prefix(&prefix);
                     handle_site_state(new_key, &state_bytes);
-                    migrate_state_to_new_key(prefix, &state_bytes);
-                    // Persist the new contract key so migration doesn't re-run
+                    migrate_state_to_new_key(&prefix, &state_bytes);
                     super::delegate::save_known_sites();
-                    // Cancel any concurrent legacy-hash probes still
-                    // in flight for this prefix — their responses, if
-                    // they land after ours, would overwrite the fresh
-                    // state with whatever lives at an older hash.
-                    clear_pending_migrations_for_prefix(prefix);
-                } else {
-                    // Old state gone from network — don't eagerly retry
-                    // the current key here. Several migration probes
-                    // may be running for the same prefix; let each one
-                    // resolve independently. If the current key itself
-                    // was not separately GET'd by the caller, the
-                    // NotFound branch below will still request it.
+                    finalize_prefix_capture(&prefix);
+                }
+                GetClassification::InitialCurrentKey { prefix } => {
+                    if state_bytes.is_empty() {
+                        // Empty state for the current key during the
+                        // initial capture window doesn't tell us
+                        // anything useful; let legacy probes resolve.
+                        log(&format!(
+                            "Delta: current-key GET returned empty for site {prefix} \
+                             during initial capture; awaiting legacy probes"
+                        ));
+                        return;
+                    }
                     log(&format!(
-                        "Delta: migration GET returned empty for site {prefix}"
+                        "Delta: captured fresh state for site {prefix} from current contract key"
                     ));
-                }
-            } else {
-                if !state_bytes.is_empty() {
                     handle_site_state(key, &state_bytes);
+                    finalize_prefix_capture(&prefix);
+                    subscribe_to_site_by_id(&key.id().clone());
                 }
-                // Subscribe AFTER successful GET
-                subscribe_to_site(&key);
+                GetClassification::LiveUpdate => {
+                    if !state_bytes.is_empty() {
+                        handle_site_state(key, &state_bytes);
+                    }
+                    subscribe_to_site(&key);
+                }
+                GetClassification::Unknown => {
+                    if !state_bytes.is_empty() {
+                        handle_site_state(key, &state_bytes);
+                    }
+                    subscribe_to_site(&key);
+                }
             }
         }
         ContractResponse::UpdateNotification { key, update } => {
@@ -401,6 +521,17 @@ pub fn fire_legacy_contract_migrations(prefix: &str, current_key_b58: &str) {
 /// after one migration GET resolves successfully, so that subsequent
 /// responses from probes for the same prefix (racing older contract
 /// hashes) can't overwrite the just-migrated state with stale data.
+/// Mark a prefix's initial capture as complete: cancel any remaining
+/// legacy-hash probes for it and remove it from `MIGRATING_PREFIXES`
+/// so that later responses take the `LiveUpdate` path and can't
+/// overwrite the captured state with stale data.
+fn finalize_prefix_capture(prefix: &str) {
+    clear_pending_migrations_for_prefix(prefix);
+    MIGRATING_PREFIXES.with_mut(|set| {
+        set.remove(prefix);
+    });
+}
+
 fn clear_pending_migrations_for_prefix(prefix: &str) {
     PENDING_MIGRATIONS.with_mut(|pending| {
         pending.retain(|_, p| p != prefix);
@@ -575,6 +706,88 @@ mod tests {
         arr
     }
 
+    fn pending(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn migrating(prefixes: &[&str]) -> BTreeSet<String> {
+        prefixes.iter().map(|p| p.to_string()).collect()
+    }
+
+    #[test]
+    fn classifier_routes_pending_migration_key_even_if_prefix_not_migrating() {
+        // A legacy-hash probe response must route through the
+        // migration branch because the key itself is in
+        // PENDING_MIGRATIONS, regardless of whether the prefix is
+        // still in MIGRATING_PREFIXES. (The caller later checks the
+        // migrating flag to decide whether to drop a late response.)
+        let pending = pending(&[("legacy_key_b58", "abcdef1234")]);
+        let migrating = migrating(&[]);
+        let c = classify_get_response("legacy_key_b58", &pending, &migrating, None);
+        assert_eq!(
+            c,
+            GetClassification::PendingMigration {
+                prefix: "abcdef1234".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classifier_routes_current_key_during_initial_capture() {
+        // GET for the current contract key (not in PENDING_MIGRATIONS)
+        // while its prefix is still in the initial-capture window must
+        // be treated as `InitialCurrentKey` so the caller can cancel
+        // sibling legacy probes once this one succeeds.
+        let pending = pending(&[]);
+        let migrating = migrating(&["abcdef1234"]);
+        let c = classify_get_response("current_key_b58", &pending, &migrating, Some("abcdef1234"));
+        assert_eq!(
+            c,
+            GetClassification::InitialCurrentKey {
+                prefix: "abcdef1234".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classifier_routes_post_capture_to_live_update() {
+        // Same current-key GET *after* the prefix has been removed
+        // from MIGRATING_PREFIXES must route to LiveUpdate so normal
+        // UpdateNotification merging continues to work in steady state.
+        let pending = pending(&[]);
+        let migrating = migrating(&[]);
+        let c = classify_get_response("current_key_b58", &pending, &migrating, Some("abcdef1234"));
+        assert_eq!(c, GetClassification::LiveUpdate);
+    }
+
+    #[test]
+    fn classifier_routes_unknown_key_to_unknown() {
+        let pending = pending(&[]);
+        let migrating = migrating(&[]);
+        let c = classify_get_response("mystery_key", &pending, &migrating, None);
+        assert_eq!(c, GetClassification::Unknown);
+    }
+
+    #[test]
+    fn classifier_prefers_pending_over_migrating_set() {
+        // If a key is BOTH in PENDING_MIGRATIONS and its prefix is in
+        // MIGRATING_PREFIXES, the pending branch must win — we need
+        // to run the migration PUT, which the InitialCurrentKey
+        // branch would skip.
+        let pending = pending(&[("legacy_key", "abcdef1234")]);
+        let migrating = migrating(&["abcdef1234"]);
+        let c = classify_get_response("legacy_key", &pending, &migrating, Some("abcdef1234"));
+        assert_eq!(
+            c,
+            GetClassification::PendingMigration {
+                prefix: "abcdef1234".to_string()
+            }
+        );
+    }
+
     #[test]
     fn contract_id_is_deterministic_and_depends_on_both_hash_and_prefix() {
         // Different hashes must produce different IDs for the same prefix.
@@ -613,6 +826,26 @@ mod tests {
         sorted.sort();
         sorted.dedup();
         assert_eq!(ids.len(), sorted.len(), "legacy ids must be unique");
+    }
+
+    #[test]
+    fn contract_id_matches_state_key_derivation_for_current_wasm() {
+        // Cross-consistency guard: `contract_id_for_prefix_with_hash`
+        // (used for legacy probes) and `state::contract_key_from_prefix`
+        // (used for the current key) must agree when called with the
+        // current WASM's hash. If freenet-stdlib ever changes its
+        // `ContractKey::from_params_and_code` internals in a
+        // backwards-incompatible way, this test catches it before a
+        // release strands users.
+        let current_wasm_hash: [u8; 32] = blake3::hash(SITE_CONTRACT_WASM).into();
+        let prefix = "abcdef1234";
+        let ours = contract_id_for_prefix_with_hash(prefix, &current_wasm_hash);
+        let theirs = state::contract_key_from_prefix(prefix).encoded_contract_id();
+        assert_eq!(
+            ours, theirs,
+            "legacy-probe key derivation must match state::contract_key_from_prefix; \
+             freenet-stdlib may have changed ContractKey::from_params_and_code"
+        );
     }
 
     #[test]

--- a/ui/src/freenet_api/operations.rs
+++ b/ui/src/freenet_api/operations.rs
@@ -12,51 +12,26 @@ use std::collections::BTreeMap;
 /// Site contract WASM (embedded at build time).
 const SITE_CONTRACT_WASM: &[u8] = include_bytes!("../../public/contracts/site_contract.wasm");
 
-/// Previous contract WASM BLAKE3 hash — the hash of the contract that
-/// shipped in the immediately-preceding Delta release. Used as a
-/// one-hop fallback when a restored KnownSiteRecord has no
-/// `contract_key_b58` (e.g. legacy delegates from before
-/// b82d3bc that pre-dated the field). For sites that *do* carry
-/// a stored key, that key takes precedence and this constant is unused.
-///
-/// **Must be updated before every release** whose commit changes
-/// `site_contract.wasm` — otherwise users of the previous release whose
-/// legacy delegate didn't persist `contract_key_b58` will be unable to
-/// reach their existing site state and see a permanent "Loading..."
-/// screen. A change to `common/src/state.rs` (e.g. adding a new
-/// `DelegateRequest` variant) is enough to perturb the contract hash
-/// because the contract depends on `delta-core`.
-///
-/// Previous value `1188d108…` (commit 2e664c3) covered the pre-tombstone
-/// WASM but was never updated through subsequent releases, silently
-/// breaking migration whenever someone deployed a new contract WASM.
-const OLD_WASM_HASH: [u8; 32] =
-    hex_literal("b92da83dae278fcdc237d976ec926ee2fdca20e817662ae8a3aeaf09aaf47fa4");
-
-const fn hex_literal(s: &str) -> [u8; 32] {
-    let bytes = s.as_bytes();
-    let mut result = [0u8; 32];
-    let mut i = 0;
-    while i < 32 {
-        let hi = hex_nibble(bytes[i * 2]);
-        let lo = hex_nibble(bytes[i * 2 + 1]);
-        result[i] = (hi << 4) | lo;
-        i += 1;
-    }
-    result
-}
-
-const fn hex_nibble(b: u8) -> u8 {
-    match b {
-        b'0'..=b'9' => b - b'0',
-        b'a'..=b'f' => b - b'a' + 10,
-        b'A'..=b'F' => b - b'A' + 10,
-        _ => panic!("invalid hex character in OLD_WASM_HASH"),
-    }
-}
+// BLAKE3 hashes of every previous `site_contract.wasm` shipped by Delta,
+// generated from `legacy_contracts.toml` by `ui/build.rs`.
+//
+// Every release commit that changes `site_contract.wasm` (including
+// incidental rebuilds caused by touching `common/`) must first record
+// the committed WASM hash via `./scripts/add-contract-migration.sh`
+// and commit the updated `legacy_contracts.toml`. Without this, users
+// of the previous release whose delegate-stored `contract_key_b58`
+// is missing or stale are unable to reach their existing site state
+// and see a permanent "Loading..." screen.
+include!(concat!(env!("OUT_DIR"), "/legacy_contracts.rs"));
 
 /// Pending migrations: maps old contract key (base58) -> site prefix.
 /// When a GET response arrives for an old key, we PUT the state to the new key.
+///
+/// Multiple old keys may be registered for the same prefix when the UI is
+/// probing several historical contract WASM hashes at startup; the first
+/// GET that returns non-empty state wins and the rest are cleared by
+/// `clear_pending_migrations_for_prefix` to prevent an older state from
+/// racing ahead of a newer one.
 static PENDING_MIGRATIONS: GlobalSignal<BTreeMap<String, String>> =
     GlobalSignal::new(BTreeMap::new);
 
@@ -88,23 +63,30 @@ fn handle_contract_response(response: ContractResponse) {
             let state_bytes = state.to_vec();
             if let Some(prefix) = &migration_prefix {
                 if !state_bytes.is_empty() {
-                    // Migration: PUT state to new contract key
+                    // Migration: PUT state to new contract key.
                     log(&format!(
                         "Delta: migrating state for site {prefix} from old key to new key"
                     ));
                     let new_key = state::contract_key_from_prefix(prefix);
                     handle_site_state(new_key, &state_bytes);
-                    // PUT to new contract (subscribe: true in PUT handles subscription)
                     migrate_state_to_new_key(prefix, &state_bytes);
                     // Persist the new contract key so migration doesn't re-run
                     super::delegate::save_known_sites();
+                    // Cancel any concurrent legacy-hash probes still
+                    // in flight for this prefix — their responses, if
+                    // they land after ours, would overwrite the fresh
+                    // state with whatever lives at an older hash.
+                    clear_pending_migrations_for_prefix(prefix);
                 } else {
-                    // Old state gone from network - fall back to normal GET on new key
+                    // Old state gone from network — don't eagerly retry
+                    // the current key here. Several migration probes
+                    // may be running for the same prefix; let each one
+                    // resolve independently. If the current key itself
+                    // was not separately GET'd by the caller, the
+                    // NotFound branch below will still request it.
                     log(&format!(
-                        "Delta: migration GET returned empty for site {prefix}, trying new key"
+                        "Delta: migration GET returned empty for site {prefix}"
                     ));
-                    let new_key = state::contract_key_from_prefix(prefix);
-                    get_site(&new_key);
                 }
             } else {
                 if !state_bytes.is_empty() {
@@ -138,21 +120,25 @@ fn handle_contract_response(response: ContractResponse) {
         ContractResponse::NotFound { instance_id } => {
             let key_b58 = instance_id.encode();
             log(&format!("Delta: contract not found: {key_b58}"));
-            // Clean up any pending migration for this key
-            if let Some(prefix) = PENDING_MIGRATIONS.write().remove(&key_b58) {
+            // Clean up any pending migration for this key. The caller
+            // in `restore_known_sites` always issues a GET for the
+            // current contract key alongside the legacy-hash probes,
+            // so a NotFound on one legacy hash does not need to retry
+            // the current key here — that GET is already in flight.
+            if PENDING_MIGRATIONS.write().remove(&key_b58).is_some() {
                 log(&format!(
-                    "Delta: old contract gone for site {prefix}, falling back to new key"
+                    "Delta: legacy contract key {key_b58} has no state; \
+                     another probe may still succeed"
                 ));
-                let new_key = state::contract_key_from_prefix(&prefix);
-                get_site(&new_key);
-            } else {
-                // Network doesn't have this contract -- try restoring from delegate backup
-                if let Some(prefix) = find_prefix_for_contract_key_b58(&key_b58) {
-                    log(&format!(
-                        "Delta: contract not found on network, trying delegate backup for {prefix}"
-                    ));
-                    super::delegate::request_site_state_backup(&prefix);
-                }
+            } else if let Some(prefix) = find_prefix_for_contract_key_b58(&key_b58) {
+                // Network doesn't have this contract under its current
+                // key either — try restoring from a delegate backup.
+                // Only runs for sites whose current key is unknown to
+                // the network; legacy-hash probes never reach here.
+                log(&format!(
+                    "Delta: contract not found on network, trying delegate backup for {prefix}"
+                ));
+                super::delegate::request_site_state_backup(&prefix);
             }
         }
         other => {
@@ -322,21 +308,39 @@ pub fn get_site_by_id(id: &ContractInstanceId) {
     });
 }
 
-/// Compute a contract instance ID using the old WASM hash and a prefix.
-/// This lets us find state at the old contract key after a WASM upgrade.
-pub fn old_contract_id_for_prefix(prefix: &str) -> String {
+/// Compute the contract instance ID for a given `prefix` under a
+/// specific contract WASM hash. `ContractInstanceId =
+/// BLAKE3(BLAKE3(wasm) || CBOR(params))`, where BLAKE3(wasm) is already
+/// `wasm_code_hash`.
+fn contract_id_for_prefix_with_hash(prefix: &str, wasm_code_hash: &[u8; 32]) -> String {
     let params = delta_core::SiteParameters {
         prefix: prefix.to_string(),
     };
     let mut params_buf = Vec::new();
     ciborium::ser::into_writer(&params, &mut params_buf).expect("CBOR params");
 
-    // ContractInstanceId = BLAKE3(BLAKE3(wasm) || params)
     let mut hasher = blake3::Hasher::new();
-    hasher.update(&OLD_WASM_HASH);
+    hasher.update(wasm_code_hash);
     hasher.update(&params_buf);
-    let hash = hasher.finalize();
-    bs58::encode(hash.as_bytes()).into_string()
+    bs58::encode(hasher.finalize().as_bytes()).into_string()
+}
+
+/// Legacy contract instance IDs for a given site prefix — one per
+/// historical `site_contract.wasm` hash recorded in
+/// `legacy_contracts.toml`. The caller fires a migration GET for each
+/// so that sites whose on-network state lives under any prior contract
+/// key can be rescued, not just the immediately-preceding release.
+///
+/// The current contract key is excluded: callers should issue a normal
+/// `get_site` for the current key separately.
+pub fn legacy_contract_ids_for_prefix(prefix: &str, current_id_b58: &str) -> Vec<String> {
+    LEGACY_CONTRACT_HASHES
+        .iter()
+        .map(|hash| contract_id_for_prefix_with_hash(prefix, hash))
+        .filter(|id| id != current_id_b58)
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 /// GET from an old contract key for migration purposes.
@@ -372,6 +376,34 @@ pub fn get_for_migration(old_key_b58: &str, prefix: &str) {
             });
             api.send(request).await
         })
+    });
+}
+
+/// Fire migration GETs for every historical contract WASM hash recorded
+/// in `legacy_contracts.toml`. Called for sites with a missing or stale
+/// `contract_key_b58` so that state stored under any past contract key
+/// can be rescued, not just the immediately-preceding release.
+pub fn fire_legacy_contract_migrations(prefix: &str, current_key_b58: &str) {
+    let legacy_ids = legacy_contract_ids_for_prefix(prefix, current_key_b58);
+    if legacy_ids.is_empty() {
+        return;
+    }
+    log(&format!(
+        "Delta: probing {} legacy contract hash(es) for site {prefix}",
+        legacy_ids.len()
+    ));
+    for old_b58 in legacy_ids {
+        get_for_migration(&old_b58, prefix);
+    }
+}
+
+/// Drop every pending migration entry whose target is `prefix`. Called
+/// after one migration GET resolves successfully, so that subsequent
+/// responses from probes for the same prefix (racing older contract
+/// hashes) can't overwrite the just-migrated state with stale data.
+fn clear_pending_migrations_for_prefix(prefix: &str) {
+    PENDING_MIGRATIONS.with_mut(|pending| {
+        pending.retain(|_, p| p != prefix);
     });
 }
 
@@ -527,4 +559,71 @@ fn log(msg: &str) {
     web_sys::console::log_1(&msg.into());
     #[cfg(not(target_arch = "wasm32"))]
     eprintln!("{msg}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex32(s: &str) -> [u8; 32] {
+        let bytes: Vec<u8> = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect();
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        arr
+    }
+
+    #[test]
+    fn contract_id_is_deterministic_and_depends_on_both_hash_and_prefix() {
+        // Different hashes must produce different IDs for the same prefix.
+        let h1 = hex32("1188d108180a4143e6e4107b193cb90d5c08644e3830499f46186f141f182e81");
+        let h2 = hex32("b92da83dae278fcdc237d976ec926ee2fdca20e817662ae8a3aeaf09aaf47fa4");
+        let id1 = contract_id_for_prefix_with_hash("abcdef1234", &h1);
+        let id2 = contract_id_for_prefix_with_hash("abcdef1234", &h2);
+        assert_ne!(id1, id2, "different WASM hashes must yield different keys");
+
+        // Same inputs must be deterministic.
+        assert_eq!(id1, contract_id_for_prefix_with_hash("abcdef1234", &h1));
+
+        // Different prefixes under the same hash must differ.
+        let id_other = contract_id_for_prefix_with_hash("wxyz123456", &h1);
+        assert_ne!(id1, id_other);
+    }
+
+    #[test]
+    fn legacy_ids_are_deduplicated_and_exclude_current() {
+        // Pretend the "current" key matches one of the legacy hashes by
+        // passing its base58 as current_id_b58; that hash must drop out
+        // of the probe set so the UI doesn't redundantly GET its own key.
+        let legacy = hex32("1188d108180a4143e6e4107b193cb90d5c08644e3830499f46186f141f182e81");
+        let pretend_current = contract_id_for_prefix_with_hash("abcdef1234", &legacy);
+
+        let ids = legacy_contract_ids_for_prefix("abcdef1234", &pretend_current);
+        assert!(
+            !ids.contains(&pretend_current),
+            "current key must be filtered out of the legacy probe set"
+        );
+
+        // Whatever comes back must be a unique set — the test doesn't
+        // know the exact count (depends on legacy_contracts.toml) but
+        // it must match the de-duplicated expectation.
+        let mut sorted = ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(ids.len(), sorted.len(), "legacy ids must be unique");
+    }
+
+    #[test]
+    fn legacy_contract_hashes_table_is_populated() {
+        // Guard against an empty or mis-generated legacy_contracts.rs:
+        // without at least one entry, users of the immediately-preceding
+        // release who hit the no-stored-key path have no fallback.
+        assert!(
+            !LEGACY_CONTRACT_HASHES.is_empty(),
+            "legacy_contracts.toml must contain at least one entry so that users \
+             of the previous release can migrate their site state"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

When Delta republishes with a new `site_contract.wasm`, every site's contract_key changes because `contract_key = BLAKE3(BLAKE3(wasm) || params)`. Sites with a persisted `KnownSiteRecord.contract_key_b58` migrate fine, but records restored from delegates older than b82d3bc have `contract_key_b58 = None` and were falling through to a hardcoded one-hop `OLD_WASM_HASH` constant. That constant had silently rotted across releases — pointing at `1188d108…` (commit 2e664c3) while the actually-previous release shipped `b92da83d…` — so users of the previous release were stranded on a permanent "Loading..." screen after the V7 republish.

See also: https://github.com/freenet/delta/commit/356e6b6 which updated `OLD_WASM_HASH` as an emergency hotfix. This PR replaces the single-constant mechanism with a proper multi-hop registry, on the same pattern as `legacy_delegates.toml`.

## Approach

- **`legacy_contracts.toml`** — single source of truth for previous contract WASM hashes.
- **`ui/build.rs`** — parses it and emits `LEGACY_CONTRACT_HASHES: &[[u8; 32]]`.
- **`contract_id_for_prefix_with_hash`** — pure, unit-tested function governing contract-key derivation for any (prefix, hash) pair.
- **`fire_legacy_contract_migrations`** — fires a migration GET for every historical hash at startup. Uses the existing `PENDING_MIGRATIONS` map to correlate responses.
- **`clear_pending_migrations_for_prefix`** — on successful migration, cancels other in-flight probes for that prefix so a slower response from an older hash can't race ahead and overwrite fresh state.
- **`restore_known_sites`** — now always issues current-key GET + stored-but-stale probe + generic legacy sweep. The NotFound handler no longer eagerly retries the current key on every legacy-probe miss.
- **`scripts/add-contract-migration.sh`** — mirrors `scripts/add-migration.sh`. Run before touching `common/` or the contract.
- **`scripts/check-migration.sh`** — extended to enforce the contract-side recording. If the contract WASM changed since HEAD and the previous hash is not in `legacy_contracts.toml`, preflight fails loudly instead of silently stranding users.
- **`AGENTS.md`** — updated upgrade workflow.

## Tests

- `contract_id_is_deterministic_and_depends_on_both_hash_and_prefix`
- `legacy_ids_are_deduplicated_and_exclude_current`
- `legacy_contract_hashes_table_is_populated` — guards against an empty generated file.

All existing tests continue to pass: delta-core 19/19, delta-ui 6/6, site-delegate 4/4.

## Initial entries

- `C1 = 1188d108…` — pre-tombstone WASM (commit 2e664c3).
- `C2 = b92da83d…` — pre-V7 WASM (f5ecff5), where today's stranded users' state actually lives.

## WASMs

Contract and delegate WASMs are byte-identical to main. This PR is pure UI logic + scripts + registry.

[AI-assisted - Claude]