### PR TITLE
fix: fetch site state backups from legacy delegates on upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,13 +148,28 @@ is missing.
 
 ### Delegate WASM Migration
 
-When `site_delegate.wasm` changes, the delegate key changes and stored secrets (signing keys, known sites) become inaccessible under the old key.
+When `site_delegate.wasm` changes, the delegate key changes and stored secrets (signing keys, known sites, **site state backups**) become inaccessible under the old key.
 
 Migration entries in `legacy_delegates.toml` allow the UI to read from old delegate keys:
 1. Before changing delegate code: `./scripts/add-migration.sh VERSION "description"`
 2. Rebuild: `./scripts/sync-wasm.sh`
-3. On startup, the UI sends GetPublicKey to each legacy delegate key
-4. If an old delegate responds, the signing key is migrated to the current delegate
+3. On startup, the UI sends GetPublicKey, GetKnownSites, GetSigningKey to each legacy delegate
+4. When legacy KnownSites arrives, GetSiteState is also requested for each prefix from that legacy delegate
+5. If an old delegate responds, signing keys, known sites, and site state backups are migrated to the current delegate
+
+**CRITICAL: Every delegate storage key type must be migrated.** The
+legacy migration in `fire_legacy_migration()` and the KnownSites handler
+must cover ALL storage operations the delegate supports. If a new storage
+operation is added to the delegate (e.g. `StoreFoo` / `GetFoo`), the
+corresponding `GetFoo` MUST be added to the legacy migration path.
+Omitting it means that data is lost silently when the delegate WASM
+upgrades. April 2026 incident: `GetSiteState` was missing from legacy
+migration, causing sites to vanish when network state had been GC'd.
+
+**Defense in depth:** `request_site_state_backup()` (called from the
+NotFound handler) queries both the current delegate AND all legacy
+delegates, so even if the proactive fetch during KnownSites processing
+misses a prefix, the NotFound fallback catches it.
 
 ### Upgrade Workflow
 

--- a/common/src/state.rs
+++ b/common/src/state.rs
@@ -618,6 +618,22 @@ impl KnownSiteRecord {
 }
 
 /// Requests from the UI to the delegate.
+///
+/// **Migration rule:** Every `Get*` variant that reads persisted data MUST
+/// be covered by the legacy delegate migration path in
+/// `ui/src/freenet_api/delegate.rs`. When a delegate WASM upgrade changes
+/// the delegate key, data stored under the old key is only accessible via
+/// legacy migration. If a `Get*` variant is missing from the migration
+/// path, that data type is silently lost on upgrade.
+///
+/// Currently migrated:
+/// - `GetPublicKey` -- in `fire_legacy_migration()`
+/// - `GetSigningKey` -- in `fire_legacy_migration()`
+/// - `GetKnownSites` -- in `fire_legacy_migration()`
+/// - `GetSiteState` -- in KnownSites handler + `request_site_state_backup()`
+/// - `GetSigningKeyForPrefix` -- NOT migrated (V7+ only; per-prefix keys
+///   are discovered via `GetPublicKey` response and then individually
+///   migrated via `store_signing_key`)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DelegateRequest {
     /// Store the owner signing key. If prefix is set, stored per-site.

--- a/ui/src/freenet_api/delegate.rs
+++ b/ui/src/freenet_api/delegate.rs
@@ -416,6 +416,13 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                         }
                         let has_real = !real_records.is_empty();
                         let has_tombstones = !tombstones.is_empty();
+                        // Capture prefixes before restore_known_sites consumes records.
+                        // Used below to fetch delegate-backed-up state from legacy delegates.
+                        let legacy_prefixes: Vec<String> = if is_legacy {
+                            real_records.iter().map(|r| r.prefix.clone()).collect()
+                        } else {
+                            Vec::new()
+                        };
                         restore_known_sites(real_records);
                         // If legacy contributed ANY state — real records OR
                         // tombstones — persist to the current delegate so
@@ -426,6 +433,19 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
                         if is_legacy && (has_real || has_tombstones) {
                             save_known_sites();
                             *CURRENT_SITES_LOADED.write() = true;
+                            // Fetch backed-up site state from this legacy
+                            // delegate. If the network GETs all fail (state
+                            // GC'd, node offline, etc.), the delegate backup
+                            // is the only remaining copy of the user's data.
+                            // handle_restored_site_state only overwrites
+                            // default (empty) state, so a successful network
+                            // GET always wins over a stale backup.
+                            for prefix in &legacy_prefixes {
+                                let req = delta_core::DelegateRequest::GetSiteState {
+                                    prefix: prefix.clone(),
+                                };
+                                send_to_delegate_key(&req, responding_key.clone());
+                            }
                         }
                     }
 
@@ -841,7 +861,19 @@ pub fn request_site_state_backup(prefix: &str) {
     let request = delta_core::DelegateRequest::GetSiteState {
         prefix: prefix.to_string(),
     };
+    // Try the current delegate first.
     send_delegate_request(&request);
+    // Also try every legacy delegate -- the backup may be stranded under
+    // an old delegate key if the user upgraded without the state being
+    // migrated to the current delegate yet.
+    #[cfg(target_arch = "wasm32")]
+    {
+        for (key_bytes, code_hash_bytes) in LEGACY_DELEGATES.iter() {
+            let legacy_code_hash = CodeHash::new(*code_hash_bytes);
+            let legacy_delegate_key = DelegateKey::new(*key_bytes, legacy_code_hash);
+            send_to_delegate_key(&request, legacy_delegate_key);
+        }
+    }
 }
 
 /// Handle a restored site state from delegate backup -- PUT it to the network.
@@ -867,6 +899,10 @@ fn handle_restored_site_state(prefix: &str, state_bytes: &[u8]) {
             site.name = site_state.config.config.name.clone();
             site.owner_pubkey = site_state.owner.to_bytes();
             drop(sites);
+
+            // Persist the backup to the current delegate so it
+            // survives future delegate WASM upgrades.
+            backup_site_state(prefix, &site_state);
 
             // PUT the backed-up state to the network to restore it
             let params = delta_core::SiteParameters {


### PR DESCRIPTION
## Problem

Sites vanish permanently after a delegate WASM upgrade when the network has garbage-collected the contract state. The legacy delegate migration (`fire_legacy_migration`) only requests `GetPublicKey`, `GetKnownSites`, and `GetSigningKey` from old delegates -- but NOT `GetSiteState`. The delegate backup (the only surviving copy of the user's site data when network state is gone) is stranded under the old delegate key and never fetched.

Reported by Ivvor in #9: two sites with full keys disappeared after a recent update. Exported backup keys also failed because the contract state was unreachable under both the old and new contract keys.

## Approach

Three changes, each providing defense in depth:

1. **Proactive backup fetch during legacy migration**: When legacy `KnownSites` arrives, immediately request `GetSiteState` for each prefix from the responding legacy delegate. This runs in parallel with network GETs for the same prefix.

2. **Defensive fallback in NotFound handler**: `request_site_state_backup()` (called when a network GET returns NotFound) now queries ALL legacy delegates in addition to the current one. This handles the case where a user imports a key after the upgrade.

3. **Forward-persist restored backups**: `handle_restored_site_state()` now also backs up the restored state to the current delegate, so it survives future delegate WASM upgrades without requiring the legacy migration to succeed again.

`handle_restored_site_state` only overwrites default (empty) state, so a successful network GET always wins over a stale delegate backup.

Also documents the migration coverage requirement: every `Get*` variant in `DelegateRequest` that reads persisted data MUST be covered by the legacy migration path, otherwise that data is silently lost on upgrade.

## Testing

- `cargo test` passes (5 tests)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo check -p delta-ui --target wasm32-unknown-unknown` clean

Manual verification needed: upgrade a node with existing sites and verify they survive.

Closes #9

[AI-assisted - Claude]