### PR TITLE
fix(editor): convert UTF-16 cursor index to UTF-8 before slicing

### DIFF
--- a/ui/src/components/editor.rs
+++ b/ui/src/components/editor.rs
@@ -71,7 +71,7 @@ pub fn Editor() -> Element {
         // `cursor_pos` is a UTF-8 byte offset stored by
         // `update_autocomplete`. Clamp to a valid char boundary in
         // case the content was edited between the input event and
-        // this callback firing — slicing inside a multi-byte char
+        // this callback firing; slicing inside a multi-byte char
         // would panic with "unreachable" in WASM.
         let mut pos = (*cursor_pos.read()).min(content.len());
         while pos > 0 && !content.is_char_boundary(pos) {
@@ -306,8 +306,8 @@ pub fn Editor() -> Element {
 /// JS strings count UTF-16 code units; Rust strings are UTF-8 byte
 /// sequences. Slicing `text[..utf16_pos]` directly panics with
 /// "unreachable" in WASM whenever the cursor lands inside or after
-/// any non-ASCII character (·, é, emoji, CJK …). The result is always
-/// on a UTF-8 char boundary.
+/// any non-ASCII character (e.g. `·`, `é`, emoji, CJK). The result
+/// is always on a UTF-8 char boundary.
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 pub(crate) fn utf16_to_byte_index(s: &str, utf16_pos: usize) -> usize {
     let mut utf16 = 0usize;
@@ -317,10 +317,10 @@ pub(crate) fn utf16_to_byte_index(s: &str, utf16_pos: usize) -> usize {
         }
         let next = utf16 + ch.len_utf16();
         if utf16_pos < next {
-            // The position lies inside a surrogate pair (rare — browsers
-            // generally don't put cursors between halves of a pair). Snap
-            // to the start of the char so the resulting byte index is on
-            // a valid UTF-8 boundary.
+            // The position lies inside a surrogate pair (rare;
+            // browsers don't normally put cursors between halves of
+            // a pair). Snap to the start of the char so the
+            // resulting byte index is on a valid UTF-8 boundary.
             return byte_idx;
         }
         utf16 = next;

--- a/ui/src/components/editor.rs
+++ b/ui/src/components/editor.rs
@@ -68,7 +68,15 @@ pub fn Editor() -> Element {
     // Insert a page link (or create a new page)
     let mut insert_link = move |id: PageId, title: &str| {
         let content = state::EDITOR_CONTENT.read().clone();
-        let pos = (*cursor_pos.read()).min(content.len());
+        // `cursor_pos` is a UTF-8 byte offset stored by
+        // `update_autocomplete`. Clamp to a valid char boundary in
+        // case the content was edited between the input event and
+        // this callback firing — slicing inside a multi-byte char
+        // would panic with "unreachable" in WASM.
+        let mut pos = (*cursor_pos.read()).min(content.len());
+        while pos > 0 && !content.is_char_boundary(pos) {
+            pos -= 1;
+        }
         let before = &content[..pos];
 
         if id == u64::MAX {
@@ -291,6 +299,35 @@ pub fn Editor() -> Element {
     }
 }
 
+/// Convert a JavaScript UTF-16 code-unit offset (as returned by
+/// `HtmlTextAreaElement::selection_start`) to a UTF-8 byte offset
+/// suitable for slicing a Rust `&str`.
+///
+/// JS strings count UTF-16 code units; Rust strings are UTF-8 byte
+/// sequences. Slicing `text[..utf16_pos]` directly panics with
+/// "unreachable" in WASM whenever the cursor lands inside or after
+/// any non-ASCII character (·, é, emoji, CJK …). The result is always
+/// on a UTF-8 char boundary.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub(crate) fn utf16_to_byte_index(s: &str, utf16_pos: usize) -> usize {
+    let mut utf16 = 0usize;
+    for (byte_idx, ch) in s.char_indices() {
+        if utf16_pos <= utf16 {
+            return byte_idx;
+        }
+        let next = utf16 + ch.len_utf16();
+        if utf16_pos < next {
+            // The position lies inside a surrogate pair (rare — browsers
+            // generally don't put cursors between halves of a pair). Snap
+            // to the start of the char so the resulting byte index is on
+            // a valid UTF-8 boundary.
+            return byte_idx;
+        }
+        utf16 = next;
+    }
+    s.len()
+}
+
 /// Check if cursor is inside [[ and update autocomplete state.
 #[allow(clippy::ptr_arg, clippy::too_many_arguments, unused_variables)]
 fn update_autocomplete(
@@ -311,17 +348,18 @@ fn update_autocomplete(
             .and_then(|d| d.get_element_by_id("delta-editor"))
             .and_then(|e| e.dyn_into::<web_sys::HtmlTextAreaElement>().ok())
         {
-            let pos = el.selection_start().ok().flatten().unwrap_or(0) as usize;
-            *cursor_pos.write() = pos;
+            let utf16_pos = el.selection_start().ok().flatten().unwrap_or(0) as usize;
+            let byte_pos = utf16_to_byte_index(text, utf16_pos);
+            *cursor_pos.write() = byte_pos;
 
-            let before_cursor = &text[..pos.min(text.len())];
+            let before_cursor = &text[..byte_pos];
             if let Some(open) = before_cursor.rfind("[[") {
                 let between = &before_cursor[open + 2..];
                 if !between.contains("]]") && !between.contains('\n') {
                     web_sys::console::log_1(
                         &format!(
                             "Delta: autocomplete triggered, query='{}' pos={}",
-                            between, pos
+                            between, byte_pos
                         )
                         .into(),
                     );
@@ -335,4 +373,75 @@ fn update_autocomplete(
     }
     ac_visible.set(false);
     ac_query.set(None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::utf16_to_byte_index;
+
+    #[test]
+    fn ascii_offsets_match_byte_offsets() {
+        assert_eq!(utf16_to_byte_index("abc", 0), 0);
+        assert_eq!(utf16_to_byte_index("abc", 1), 1);
+        assert_eq!(utf16_to_byte_index("abc", 3), 3);
+    }
+
+    #[test]
+    fn two_byte_utf8_char_advances_by_two_bytes_per_unit() {
+        // "·" is U+00B7: 1 UTF-16 unit, 2 UTF-8 bytes.
+        let s = "a·b";
+        assert_eq!(utf16_to_byte_index(s, 0), 0);
+        assert_eq!(utf16_to_byte_index(s, 1), 1); // after 'a'
+        assert_eq!(utf16_to_byte_index(s, 2), 3); // after '·' (skip its 2 bytes)
+        assert_eq!(utf16_to_byte_index(s, 3), 4); // after 'b'
+    }
+
+    #[test]
+    fn three_byte_utf8_char_advances_by_three_bytes_per_unit() {
+        // "汉" is U+6C49: 1 UTF-16 unit, 3 UTF-8 bytes.
+        let s = "a汉b";
+        assert_eq!(utf16_to_byte_index(s, 1), 1);
+        assert_eq!(utf16_to_byte_index(s, 2), 4);
+        assert_eq!(utf16_to_byte_index(s, 3), 5);
+    }
+
+    #[test]
+    fn surrogate_pair_consumes_two_utf16_units() {
+        // "🎉" is U+1F389: surrogate pair (2 UTF-16 units), 4 UTF-8 bytes.
+        let s = "a🎉b";
+        assert_eq!(utf16_to_byte_index(s, 1), 1); // after 'a'
+        assert_eq!(utf16_to_byte_index(s, 2), 1); // mid-surrogate, snap to char start
+        assert_eq!(utf16_to_byte_index(s, 3), 5); // after '🎉'
+        assert_eq!(utf16_to_byte_index(s, 4), 6); // after 'b'
+    }
+
+    #[test]
+    fn out_of_range_clamps_to_string_len() {
+        let s = "a·b";
+        assert_eq!(utf16_to_byte_index(s, 100), s.len());
+    }
+
+    #[test]
+    fn zero_pos_returns_zero() {
+        assert_eq!(utf16_to_byte_index("", 0), 0);
+        assert_eq!(utf16_to_byte_index("·", 0), 0);
+    }
+
+    #[test]
+    fn slicing_with_returned_index_never_panics() {
+        // Regression: the previous code did `&text[..selection_start]`,
+        // which panics inside any non-ASCII char. With the converter
+        // every reachable cursor position must yield a valid char
+        // boundary regardless of what is to the left.
+        let cases = ["·abc", "a·b·c", "汉a汉", "🎉x🎉", "café"];
+        for s in cases {
+            // Use the largest UTF-16 length the string can produce so
+            // we stress every code-unit position 0..=utf16_len.
+            let utf16_len: usize = s.chars().map(|c| c.len_utf16()).sum();
+            for pos in 0..=utf16_len + 2 {
+                let idx = utf16_to_byte_index(s, pos);
+                let _ = &s[..idx]; // must not panic
+            }
+        }
+    }
 }

--- a/ui/src/freenet_api/connection.rs
+++ b/ui/src/freenet_api/connection.rs
@@ -57,12 +57,8 @@ pub fn connect_to_freenet() {
                 Ok(response) => super::operations::handle_response(response),
                 Err(e) => {
                     let msg = format!("Delta: API error: {e:?}");
-                    let truncated = if msg.len() > 200 {
-                        format!("{}...", &msg[..200])
-                    } else {
-                        msg.clone()
-                    };
-                    web_sys::console::error_1(&truncated.into());
+                    let truncated = truncate_for_log(&msg, 200);
+                    web_sys::console::error_1(&truncated.as_ref().into());
                     // If a GET timed out, try restoring from delegate backup
                     if msg.contains("GET operation timed out") {
                         super::operations::handle_get_timeout(&msg);
@@ -71,11 +67,7 @@ pub fn connect_to_freenet() {
             },
             move |error| {
                 let msg = error.to_string();
-                let truncated = if msg.len() > 200 {
-                    format!("Delta: connection error: {}...", &msg[..200])
-                } else {
-                    format!("Delta: connection error: {msg}")
-                };
+                let truncated = format!("Delta: connection error: {}", truncate_for_log(&msg, 200));
                 web_sys::console::error_1(&truncated.into());
                 *CONNECTION_STATUS.write() =
                     ConnectionStatus::Error("Connection failed".to_string());
@@ -89,6 +81,59 @@ pub fn connect_to_freenet() {
         );
 
         *WEB_API.write() = Some(web_api);
+    }
+}
+
+/// Truncate `msg` to at most `max_bytes` UTF-8 bytes, appending `…`
+/// if any bytes were dropped. Always cuts on a char boundary so a
+/// long error message containing non-ASCII bytes (which can sit
+/// across the cut point) does not panic with `&str[..n]` slicing.
+pub(crate) fn truncate_for_log(msg: &str, max_bytes: usize) -> std::borrow::Cow<'_, str> {
+    if msg.len() <= max_bytes {
+        return std::borrow::Cow::Borrowed(msg);
+    }
+    let mut cut = max_bytes;
+    while cut > 0 && !msg.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    std::borrow::Cow::Owned(format!("{}…", &msg[..cut]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_for_log;
+
+    #[test]
+    fn short_message_passes_through() {
+        assert_eq!(truncate_for_log("hello", 200).as_ref(), "hello");
+    }
+
+    #[test]
+    fn long_ascii_message_truncates_with_ellipsis() {
+        let s = "x".repeat(250);
+        let out = truncate_for_log(&s, 200);
+        assert!(out.ends_with('…'));
+        // 200 'x' bytes plus the 3-byte ellipsis.
+        assert_eq!(out.as_ref().len(), 200 + '…'.len_utf8());
+    }
+
+    #[test]
+    fn non_ascii_at_boundary_does_not_panic() {
+        // "·" is 2 bytes; place it so naive `&s[..3]` would land
+        // mid-char.
+        let s = format!("ab·{}", "x".repeat(300));
+        let out = truncate_for_log(&s, 3);
+        // We cut at 2 (start of '·' fails boundary at 3, so we walk
+        // back to 2). Output is "ab" + ellipsis.
+        assert_eq!(out.as_ref(), "ab…");
+    }
+
+    #[test]
+    fn equal_length_returns_borrowed() {
+        let s = "exactly twenty char!";
+        assert_eq!(s.len(), 20);
+        let out = truncate_for_log(s, 20);
+        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
     }
 }
 


### PR DESCRIPTION
## Problem

Editing a Delta page that contains any non-ASCII character (·, é, CJK, emoji, …) produces a flood of WASM panics:

```
Uncaught RuntimeError: unreachable
    at delta-ui_bg-…wasm:0xe4cfd
    at delta-ui_bg-…wasm:0xefa33
    at delta-ui_bg-…wasm:0xfa82b
    …
```

Every keystroke after a multi-byte character fires the panic, so the editor effectively cannot be used on pages with international punctuation, dashes, accented letters, or emoji. User-reported.

## Root cause

`update_autocomplete` reads the textarea cursor via `HtmlTextAreaElement::selection_start`, which returns a position in **JavaScript UTF-16 code units**, then uses that integer directly as a **UTF-8 byte index** to slice the Rust `&str`:

```rust
let pos = el.selection_start().ok().flatten().unwrap_or(0) as usize;
*cursor_pos.write() = pos;
let before_cursor = &text[..pos.min(text.len())];   // panics
```

For a 2-byte UTF-8 character like `·`, one UTF-16 code unit corresponds to two UTF-8 bytes; for a 4-byte character like `🎉`, two UTF-16 code units correspond to four UTF-8 bytes. The byte index then falls inside a multi-byte sequence and `str::index` panics. Rust panics in WASM compile to the `unreachable` instruction, which is what shows up in the console.

`insert_link` consumes the same `cursor_pos` signal, so accepting an autocomplete suggestion was vulnerable to the same panic.

## Solution

Two small UTF-8-safety helpers, each with unit tests:

- `utf16_to_byte_index(s, utf16_pos)` walks `char_indices` and accumulates `char.len_utf16()` to find the UTF-8 byte index for a given JS code-unit cursor position. The result is always on a `&str` slice boundary; positions inside a surrogate pair (rare; browsers do not normally place cursors there) snap to the surrogate's start. Conversion happens once in `update_autocomplete` immediately after reading `selection_start`, and the byte offset is what gets stored in `cursor_pos`. `insert_link` additionally clamps to a char boundary in case the editor content was mutated between the input event and the autocomplete callback.

- `truncate_for_log(msg, max_bytes)` walks back to a char boundary before slicing. The two `&msg[..200]` sites in `connection.rs::connect_to_freenet` had the same latent panic for sufficiently long error messages with non-ASCII bytes near the cut point. Pre-existing but the same bug class, fixed in the same PR per the project's "fix problems you encounter" rule.

## Testing

11 new unit tests in `ui/src/components/editor.rs` and `ui/src/freenet_api/connection.rs`:

- ASCII positions match byte positions
- 2-byte UTF-8 (`·`) advances correctly
- 3-byte UTF-8 (`汉`) advances correctly
- 4-byte UTF-8 / surrogate pair (`🎉`) advances correctly, including snap-to-start mid-pair
- Out-of-range positions clamp to `s.len()`, zero positions return zero
- Property-style regression that exhaustively probes every reachable UTF-16 position over a battery of multi-byte strings and asserts the returned byte index is always a valid slice boundary
- `truncate_for_log` short-pass-through, long-ASCII, mid-multibyte cut, and exact-length cases

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --bin delta-ui` green (31 passed), `dx build --release` produces a working WASM bundle.

## Migration / republish

UI-only change: `ui/src/components/editor.rs` and `ui/src/freenet_api/connection.rs`. Nothing under `common/`, `contracts/site-contract/`, or `delegates/site-delegate/` changes, so neither `site_contract.wasm` nor `site_delegate.wasm` changes — contract keys and delegate keys stay identical. **No `legacy_delegates.toml` / `legacy_contracts.toml` entry is required.** Republishing is just `cargo make publish-delta` to ship a new webapp archive; users get the fix on next page load.

## On the "Â·" mojibake the user also reported

The renderer pipeline is `String` end-to-end (`Page.content: String` → `markdown::to_html_with_options` → `dangerous_inner_html`) with no charset conversion anywhere. The most likely explanation for "Design doc Â· Status: …" is that the page's content was saved with corrupted bytes during an earlier session that was hitting the panic above (the `oninput` handler can write `EDITOR_CONTENT` in a partially-mutated state when the autocomplete code panics mid-callback), and the corruption is persisted in the contract state. After this fix, editing the affected paragraph once will normalise the bytes; if the mojibake reappears in a freshly-typed paragraph after deploy, that is a separate bug worth a follow-up issue.

## CI note

The `Delegate migration safety` check fails on this PR with the same WASM-reproducibility mismatch that's been failing on every commit since `bfded95` on main. Local `./scripts/check-migration.sh` passes; the divergence is between local toolchain and the CI runner's `dtolnay/rust-toolchain@stable`. Pre-existing and not caused by this PR (which doesn't touch any WASM at all).

## Fixes

(no GitHub issue — reported directly by user)

[AI-assisted - Claude]