### PR TITLE
build: pin rustc via rust-toolchain.toml + verify legacy_delegates table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
+        # No `with: toolchain:` — `dtolnay/rust-toolchain` honours the
+        # rust-toolchain.toml file at the repo root. Pinning lives in
+        # one place; CI and local devs run the same rustc, which is
+        # what makes the migration-safety check in the next job
+        # actually able to compare hashes.
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-          components: clippy, rustfmt
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -54,9 +56,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
+        # See note in the `check` job: pin lives in rust-toolchain.toml.
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
 
       - name: Install b3sum
         run: cargo install b3sum
@@ -71,16 +72,27 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Print toolchain (for diagnostics if hashes mismatch)
+        run: rustc --version --verbose
+
       - name: Verify delegate WASM matches source
         run: |
           ./scripts/build-wasm.sh -p site-delegate
           COMMITTED=$(b3sum ui/public/contracts/site_delegate.wasm | cut -d' ' -f1)
           BUILT=$(b3sum target/wasm32-unknown-unknown/release/site_delegate.wasm | cut -d' ' -f1)
           if [ "$COMMITTED" != "$BUILT" ]; then
-            echo "::error::Committed delegate WASM is stale (doesn't match built from source)"
+            echo "::error::Committed delegate WASM does not match what this toolchain produced from source."
             echo "  committed: $COMMITTED"
             echo "  built:     $BUILT"
-            echo "Run ./scripts/sync-wasm.sh to update"
+            echo ""
+            echo "If you intentionally changed delegate code, run:"
+            echo "  ./scripts/add-migration.sh V_N \"<short description>\""
+            echo "  ./scripts/sync-wasm.sh"
+            echo ""
+            echo "If this CI failure surprises you (no delegate change in this PR),"
+            echo "the toolchain may have drifted from rust-toolchain.toml. The runner"
+            echo "above prints rustc --version --verbose; compare against:"
+            echo "  $(grep '^channel' rust-toolchain.toml || echo '(rust-toolchain.toml not found)')"
             exit 1
           fi
 
@@ -90,9 +102,17 @@ jobs:
           COMMITTED=$(b3sum ui/public/contracts/site_contract.wasm | cut -d' ' -f1)
           BUILT=$(b3sum target/wasm32-unknown-unknown/release/site_contract.wasm | cut -d' ' -f1)
           if [ "$COMMITTED" != "$BUILT" ]; then
-            echo "::error::Committed contract WASM is stale (doesn't match built from source)"
+            echo "::error::Committed contract WASM does not match what this toolchain produced from source."
             echo "  committed: $COMMITTED"
             echo "  built:     $BUILT"
-            echo "Run ./scripts/sync-wasm.sh to update"
+            echo ""
+            echo "If you intentionally changed contract code or common/, run:"
+            echo "  ./scripts/add-contract-migration.sh C_N \"<short description>\""
+            echo "  ./scripts/sync-wasm.sh"
+            echo ""
+            echo "If this CI failure surprises you (no contract / common/ change in"
+            echo "this PR), the toolchain may have drifted from rust-toolchain.toml."
+            echo "The runner above prints rustc --version --verbose; compare against:"
+            echo "  $(grep '^channel' rust-toolchain.toml || echo '(rust-toolchain.toml not found)')"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,25 @@ the `filter_applicable_tombstones` unit tests pin them.
 
 The repo pins rustc via `rust-toolchain.toml` (currently `1.94.1`). This is **load-bearing for the migration system**: the delegate key is `BLAKE3(BLAKE3(wasm) || params)`, so any change in WASM bytes — including bytes produced by an LLVM upgrade in a newer rustc — produces a new delegate key and orphans every user's stored data unless a migration entry is recorded first.
 
-The migration-safety check in `.github/workflows/ci.yml` rebuilds the WASMs from source on each PR and refuses to merge if the committed hashes don't match. With a pinned toolchain CI and local always agree, so the gate provides real signal. If `rust-toolchain.toml` changes, treat it like any other delegate / contract WASM change: run `./scripts/add-migration.sh` (and `./scripts/add-contract-migration.sh` if `common/` or contract code is also touched) **before** running `./scripts/sync-wasm.sh`.
+The migration-safety check in `.github/workflows/ci.yml` rebuilds the WASMs from source on each PR and refuses to merge if the committed hashes don't match. With a pinned toolchain CI and local always agree, so the gate provides real signal.
 
 The same pattern is used in `freenet/river` and `freenet/freenet-core`. Don't let the pin drift past those sibling repos without coordinating, since a Freenet dApp ecosystem with mismatched toolchain pins will silently produce different hashes for shared dependencies.
+
+### Upgrading the pinned rustc
+
+Bumping `channel` in `rust-toolchain.toml` is a **data-migration gesture**, not a routine maintenance task. Treat it the same way you treat changing delegate or contract code: predecessor hashes recorded first, WASM regenerated, single-commit PR, post-merge republish, browser verification. The full canonical procedure lives at the top of `rust-toolchain.toml`; the summary:
+
+1. `rustup install <new-channel>` (and add `rustfmt`, `clippy`, `wasm32-unknown-unknown` to it).
+2. `./scripts/add-migration.sh V_N "rustc X.Y.Z -> X.Y.Z+1"` — records the current delegate WASM hash in `legacy_delegates.toml` BEFORE the bump.
+3. `./scripts/add-contract-migration.sh C_N "rustc X.Y.Z -> X.Y.Z+1"` — same for the contract WASM.
+4. Bump `channel` in `rust-toolchain.toml`.
+5. `./scripts/sync-wasm.sh` — rebuilds with the new channel and copies the new bytes into `ui/public/contracts/`. The hash must differ from the one just recorded.
+6. `./scripts/check-migration.sh` — must print "Safe to publish."
+7. Single commit, single PR: `rust-toolchain.toml`, both `legacy_*.toml`, both `ui/public/contracts/*.wasm`. Reviewers see the whole atomic change in one diff.
+8. After merge: `cargo make publish-delta`.
+9. Browser verification on the live deploy: existing site still listed, at least one page loads (legacy migration of state backup worked), an edit saves and round-trips (new key functional). **Don't consider the bump done until step 9 passes.**
+
+Skipping any step silently breaks data continuity for every existing user; there is no automatic recovery. The procedure is in the toml file rather than a separate runbook so the person about to run `vim rust-toolchain.toml` has it directly in front of them.
 
 ## Contract Upgrade / State Migration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,14 @@ would appear to fail.
 Any change to the KnownSites response handler must preserve both rules;
 the `filter_applicable_tombstones` unit tests pin them.
 
+## Reproducible WASM Builds
+
+The repo pins rustc via `rust-toolchain.toml` (currently `1.94.1`). This is **load-bearing for the migration system**: the delegate key is `BLAKE3(BLAKE3(wasm) || params)`, so any change in WASM bytes — including bytes produced by an LLVM upgrade in a newer rustc — produces a new delegate key and orphans every user's stored data unless a migration entry is recorded first.
+
+The migration-safety check in `.github/workflows/ci.yml` rebuilds the WASMs from source on each PR and refuses to merge if the committed hashes don't match. With a pinned toolchain CI and local always agree, so the gate provides real signal. If `rust-toolchain.toml` changes, treat it like any other delegate / contract WASM change: run `./scripts/add-migration.sh` (and `./scripts/add-contract-migration.sh` if `common/` or contract code is also touched) **before** running `./scripts/sync-wasm.sh`.
+
+The same pattern is used in `freenet/river` and `freenet/freenet-core`. Don't let the pin drift past those sibling repos without coordinating, since a Freenet dApp ecosystem with mismatched toolchain pins will silently produce different hashes for shared dependencies.
+
 ## Contract Upgrade / State Migration
 
 ### When Contract WASM Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
 name = "delta-ui"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "bs58",
  "chrono",
  "ciborium",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,20 +11,87 @@
 # orphans every user's data.
 #
 # This is the same reason river/main pins to the same channel.
-# When updating this pin (any rustc bump):
+# `freenet/freenet-core` also pins; aim to keep these aligned so a
+# shared dependency built in two repos produces the same bytes.
 #
-#   1. ./scripts/add-migration.sh V_N "rustc X.Y.Z -> X.Y.Z+1"
-#      -- records the CURRENT (old-rustc) delegate key in
-#         legacy_delegates.toml so the new delegate can read
-#         legacy state on first run.
-#   2. ./scripts/add-contract-migration.sh C_N "rustc X.Y.Z -> X.Y.Z+1"
-#      -- same as above for the contract WASM hash.
-#   3. Bump `channel` below.
-#   4. ./scripts/sync-wasm.sh -- regenerates the committed WASMs
-#      with the new toolchain. The CI migration-safety check will
-#      pass once committed and CI agree on the same rustc.
-#   5. Commit legacy_*.toml + ui/public/contracts/*.wasm + this
-#      file together in a single PR.
+# ============================================================
+# Procedure for bumping this pin (canonical; same as AGENTS.md)
+# ============================================================
+#
+# Run the steps in order from a clean working tree on a topic
+# branch. Each step has a verification you should perform before
+# moving on. Do NOT batch-run them blind.
+#
+# 0. Install the new toolchain locally so cargo can use it:
+#       rustup install <new-channel>
+#       rustup component add rustfmt clippy --toolchain <new-channel>
+#       rustup target add wasm32-unknown-unknown --toolchain <new-channel>
+#
+# 1. Record the CURRENT delegate WASM hash (BEFORE the bump):
+#       ./scripts/add-migration.sh V_N "rustc X.Y.Z -> X.Y.Z+1"
+#    The script reads ui/public/contracts/site_delegate.wasm,
+#    computes its BLAKE3 hash, and appends an [[entry]] block to
+#    legacy_delegates.toml. Verify the entry was written:
+#       tail -10 legacy_delegates.toml
+#
+# 2. Record the CURRENT contract WASM hash (BEFORE the bump):
+#       ./scripts/add-contract-migration.sh C_N "rustc X.Y.Z -> X.Y.Z+1"
+#    Same logic but for legacy_contracts.toml.
+#
+# 3. Bump the `channel` field below to the new version.
+#
+# 4. Rebuild WASMs with the new toolchain:
+#       ./scripts/sync-wasm.sh
+#    This invokes rustup with the channel from this file (you just
+#    bumped it), so the new bytes are produced and copied into
+#    ui/public/contracts/. Verify:
+#       b3sum ui/public/contracts/site_delegate.wasm
+#    Hash MUST differ from the one you just recorded in step 1.
+#
+# 5. Run the local migration check (the same one CI runs):
+#       ./scripts/check-migration.sh
+#    Must print "Safe to publish."
+#
+# 6. Commit everything together as ONE atomic change:
+#       git add rust-toolchain.toml \
+#               legacy_delegates.toml \
+#               legacy_contracts.toml \
+#               ui/public/contracts/site_delegate.wasm \
+#               ui/public/contracts/site_contract.wasm
+#       git commit -m "build: bump rustc X.Y.Z -> X.Y.Z+1"
+#    Reviewers can then verify in one diff that:
+#      (a) the predecessor hashes were recorded,
+#      (b) the WASMs changed,
+#      (c) the channel changed,
+#      (d) nothing else.
+#
+# 7. Open a PR. CI's migration-safety job rebuilds with the new
+#    pinned channel and compares against the just-committed WASMs
+#    — must match. (If it doesn't, the runner's stable doesn't
+#    include the version you pinned yet; pick a slightly older
+#    version or wait.)
+#
+# 8. After merge, republish to Freenet:
+#       cargo make publish-delta
+#    The new delegate / contract WASMs ship. Existing users boot
+#    the new UI, the legacy migration paths kick in, and their
+#    pre-bump data migrates from the old key to the new one.
+#
+# 9. Verify in a real browser:
+#       - load the published Delta with at least one existing site;
+#       - confirm the site is still listed (legacy migration of
+#         known_sites worked);
+#       - confirm at least one page loads (legacy migration of
+#         site_state backup worked);
+#       - confirm an edit saves and round-trips (new key is
+#         functional).
+#    Do NOT consider the bump done until step 9 passes against the
+#    actual deployment.
+#
+# Old legacy entries can in principle be pruned years later once we
+# are confident no users still hold data under those keys. Don't
+# rush this — leaving entries in costs nothing but a few KB in the
+# webapp bundle.
 channel = "1.94.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,30 @@
+[toolchain]
+# Pinned to keep site_delegate.wasm and site_contract.wasm builds
+# byte-deterministic across local dev and CI.
+#
+# Why this matters: the delegate key is BLAKE3(BLAKE3(wasm) || params).
+# A different rustc version produces different WASM bytes (LLVM
+# changes between releases) and therefore a different delegate key.
+# Users store their signing keys, known sites, and site state
+# backups under the current delegate's key — changing the key
+# without recording the old key in legacy_delegates.toml silently
+# orphans every user's data.
+#
+# This is the same reason river/main pins to the same channel.
+# When updating this pin (any rustc bump):
+#
+#   1. ./scripts/add-migration.sh V_N "rustc X.Y.Z -> X.Y.Z+1"
+#      -- records the CURRENT (old-rustc) delegate key in
+#         legacy_delegates.toml so the new delegate can read
+#         legacy state on first run.
+#   2. ./scripts/add-contract-migration.sh C_N "rustc X.Y.Z -> X.Y.Z+1"
+#      -- same as above for the contract WASM hash.
+#   3. Bump `channel` below.
+#   4. ./scripts/sync-wasm.sh -- regenerates the committed WASMs
+#      with the new toolchain. The CI migration-safety check will
+#      pass once committed and CI agree on the same rustc.
+#   5. Commit legacy_*.toml + ui/public/contracts/*.wasm + this
+#      file together in a single PR.
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -55,3 +55,7 @@ delta-core.workspace = true
 chrono = "0.4"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
+# Used to validate delegate_key == BLAKE3(code_hash) at compile time
+# so a typo in legacy_delegates.toml fails the build, not the live
+# UI rolling out a broken migration table.
+blake3 = "1"

--- a/ui/build.rs
+++ b/ui/build.rs
@@ -100,6 +100,20 @@ fn generate_legacy_delegates() {
         let dk_bytes = hex_to_byte_array(&entry.delegate_key, &entry.version, "delegate_key");
         let ch_bytes = hex_to_byte_array(&entry.code_hash, &entry.version, "code_hash");
 
+        // Cross-check the relationship documented at the top of
+        // legacy_delegates.toml: `delegate_key = BLAKE3(code_hash_bytes)`.
+        // Catches typos / hand-computed-wrong / a future drift in the
+        // freenet-stdlib formula at build time, before the UI ships.
+        let computed_dk: [u8; 32] = *blake3::hash(&ch_bytes).as_bytes();
+        assert_eq!(
+            dk_bytes, computed_dk,
+            "{}: delegate_key in legacy_delegates.toml does not match BLAKE3(code_hash). \
+             stored = {}, computed = {}. Did the formula change in freenet-stdlib, or is one of the fields a typo?",
+            entry.version,
+            bytes_to_hex(&dk_bytes),
+            bytes_to_hex(&computed_dk),
+        );
+
         code.push_str(&format!(
             "    // {}: {} ({})\n",
             entry.version, entry.description, entry.date
@@ -168,6 +182,14 @@ fn generate_legacy_contracts() {
     if existing != code {
         fs::write(&dest, &code).unwrap();
     }
+}
+
+fn bytes_to_hex(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
 }
 
 fn hex_to_byte_array(hex: &str, version: &str, field: &str) -> [u8; 32] {


### PR DESCRIPTION
Closes #12.

## Problem

The \`Delegate migration safety\` CI gate has been red on every PR and push to main since \`bfded95\` (2026-04-17). Every contributor has been ignoring it as a known-broken check. That's the worst possible state for a safety gate: it provides zero signal, so a real delegate-WASM regression that orphans every user's signing keys, known sites, and site state backups would look identical to the ongoing false alarm.

## Root cause

\`scripts/build-wasm.sh\` already remaps absolute paths via \`--remap-path-prefix\` (PR #4 / V8 in legacy_delegates.toml). That handled the most common reproducibility hole.

The remaining hole is the rustc version itself. \`.github/workflows/ci.yml\` used \`dtolnay/rust-toolchain@stable\` with an explicit \`with: toolchain: stable\` input, which resolves to *whatever stable is current on the GitHub runner that day*.

| | rustc | LLVM |
|---|---|---|
| Last committer (committed WASM) | 1.94.1 (e408947bf 2026-03-25) | 21.1.8 |
| CI runners (today) | 1.95.0 (59807616e 2026-04-14) | 22.1.2 |

LLVM emits subtly different code between releases, so the CI build of the same source produces a different hash:

\`\`\`
committed (1.94.1): 4d576358...
CI built (1.95.0):  1bf4ffb7...
\`\`\`

Reproduced locally with \`rustup install 1.95.0\` + rebuild — produces the exact \`1bf4ffb7...\` hash CI sees. Toolchain divergence is the sole cause.

## Fix

Pin rustc via \`rust-toolchain.toml\` (\`channel = "1.94.1"\`), matching the pattern already used in \`freenet/river\` and \`freenet/freenet-core\`. Remove the explicit \`toolchain: stable\` from both \`dtolnay/rust-toolchain@stable\` invocations so the action defers to \`rust-toolchain.toml\`. After this change CI installs the same rustc the committer uses, the migration-safety check produces real signal again, and a future rustc bump becomes a deliberate gesture that has to ship together with a \`legacy_delegates.toml\` entry.

The pin is set to **1.94.1** specifically because that matches the currently-committed (and currently-deployed) WASM bytes. No delegate-key change, no migration entry needed in this PR.

## Defense in depth

**\`ui/build.rs\`** now cross-checks every \`legacy_delegates.toml\` entry at compile time:

\`\`\`
assert(delegate_key == BLAKE3(code_hash_bytes))
\`\`\`

A typo (or a future drift in the freenet-stdlib formula) fails the build with a specific, actionable error pointing at the offending entry. Verified by deliberately corrupting V1's code_hash and observing the build refuse with a clear diff message.

**Migration-safety job** in CI now also prints \`rustc --version --verbose\` before the hash check and the failure message includes a "compare against rust-toolchain.toml" hint, so the next time the toolchain genuinely drifts the diagnosis is immediate.

## Verification

Local rustup-managed \`1.94.1\` build of both delegate and contract WASM produces hashes byte-identical with what's currently committed:

\`\`\`
delegate:  4d576358229eed2ea567d8c3275776f584a0a66f41b4b05058644da4d4fc56aa
contract:  8e36f95d436899960cf31afd76586837a3bf9f91483dcd09d26483ad02823c53
\`\`\`

So CI on this branch should produce matching hashes and \`Delegate migration safety\` should go green for the first time since the 1.94 → 1.95 rust release.

## AGENTS.md

New "Reproducible WASM Builds" section explains why the pin is load-bearing and what to do when bumping rustc (record old delegate / contract WASM hashes via the migration scripts FIRST, then bump \`channel\` and sync-wasm). The \`rust-toolchain.toml\` file itself includes the same checklist so it's discoverable from the file you'd actually be editing.

## Out of scope

- Bumping past 1.94.1 to a current stable is a deliberate data-migration gesture that should be its own PR (delete this PR's WASMs, run \`add-migration.sh\`, bump channel, run \`sync-wasm.sh\`, republish). Not done here.
- Same toolchain-pin discipline should be audited across other Freenet dApps (river already pins; other dApps unverified).

[AI-assisted - Claude]