### PR TITLE
fix(state): propagate page-order migration to network

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,16 @@ Page signatures use v2 format (`delta:page:v2:`) which covers: page_id, title, c
 
 **`updated_at` must be strictly greater than the page's current `updated_at`.** `apply_delta` and `merge` in `delta-core` dominate equal timestamps with `>=`, so an UPDATE whose `updated_at` matches what's already in state is silently dropped on the network. Any UI path that produces a page UPDATE (`save_current_page`, `rename_page`, `swap_page_order`, …) MUST route through `next_page_updated_at` in `ui/src/state.rs`, which computes `max(now_secs(), existing + 1)`. Calling `now_secs()` directly is a recurrence of the reorder bug Ivvor reported on 2026-04-29 (silent same-second collisions).
 
+**Page `order` invariants (for `swap_page_order` / `create_page` in `ui/src/state.rs`):**
+
+1. `swap_page_order` MUST sign and propagate a fresh page-UPDATE for **every** page whose order changes — not just the two pages clicked. When ANY page on the site is still at `order == 0` (legacy v1-signed pages, or pages created before the order field existed), the swap also performs a one-time site-wide migration to explicit orders `(10, 20, 30, …)` sorted by `(current_order, page_id)` to match the sidebar. Skipping the propagation step is the bug Ivvor re-reported on 2026-05-03 — the local view looked correct but unmigrated pages remained at `order = 0` on the network and clumped to the front of the sidebar after a refresh.
+
+2. `create_page` MUST assign `order = max(existing) + ORDER_STEP` via `next_create_order` (never `0`). Issuing `0` re-poisons a migrated site and re-introduces the front-of-sidebar clumping symptom.
+
+3. The orchestration helper `plan_swap` derives `pages_to_sign` from the diff between current and new orders, so a regression that re-narrows the sign set (e.g. back to "just the two clicked pages") is caught by the unit tests — not just by the lower-level `compute_swap_orders` tests.
+
+**Delegate-response routing MUST use signature verification, not `CURRENT_SITE`.** `handle_signed_page` / `handle_signed_deletion` / `handle_signed_config` in `ui/src/freenet_api/delegate.rs` look up the owning site by checking the signature against every known owner's pubkey (`find_owner_for_signed_*`). Earlier code keyed `PENDING_UPDATES` by `(CURRENT_SITE, page_id)` and consumed the entry on first response; concurrent requests for the same page silently dropped subsequent UPDATEs, and a mid-flight site switch routed a signed page into the wrong site's local state. Verification-based routing handles both correctly without a delegate WASM change.
+
 ### Page Links
 
 - `[[2]]` - renders as current page title, auto-updates on rename

--- a/ui/src/freenet_api/delegate.rs
+++ b/ui/src/freenet_api/delegate.rs
@@ -479,15 +479,56 @@ pub fn handle_delegate_response(responding_key: DelegateKey, values: Vec<Outboun
 }
 
 /// After receiving a signed page from the delegate, update local state and send to network.
+///
+/// The previous implementation correlated request-to-response via
+/// `PENDING_UPDATES` keyed by `(CURRENT_SITE, page_id)`, which had two
+/// failure modes the skeptical review on PR #17 turned up:
+/// 1. Two in-flight requests for the same `(prefix, page_id)` shared
+///    a single map entry; the first response removed it, the second
+///    response silently dropped its UPDATE on the floor (this is the
+///    exact "looks correct locally, undone on refresh" symptom we
+///    just fixed for `swap_page_order`).
+/// 2. `find_pending_key` read `CURRENT_SITE`, so if the user switched
+///    sites between request and response the late-arriving signed
+///    page would be inserted into the *wrong site's* local state and
+///    the network UPDATE for the original site would be dropped.
+///
+/// Routing now derives the owning site from the page signature
+/// itself: every `Page::verify` checks against an owner pubkey, and
+/// only the owner who actually signed it will verify. This is robust
+/// to multiple in-flight requests, site switches, and out-of-order
+/// responses without requiring a delegate WASM change.
 fn handle_signed_page(page_id: PageId, page: delta_core::Page) {
-    // Find which site/contract this is for
-    let pending = PENDING_UPDATES.write().remove(&find_pending_key(page_id));
+    let Some((prefix, contract_key)) = find_owner_for_signed_page(&page, page_id) else {
+        log(&format!(
+            "Delta: signed page {page_id} doesn't verify against any known owner — dropping"
+        ));
+        return;
+    };
 
-    // Update local state
-    let prefix = state::CURRENT_SITE.read().clone();
-    if let Some(prefix) = &prefix {
+    // Don't resurrect a page the user just tombstoned. If the user
+    // deletes a page after the delegate started signing it, the
+    // signed response can race with the deletion's tombstone; without
+    // this guard the local state would silently re-add the page and
+    // a fresh page-UPDATE would compete with the deletion-UPDATE on
+    // the network. (#17 skeptical review)
+    {
+        let sites = state::SITES.read();
+        if sites
+            .get(&prefix)
+            .map(|s| s.state.deleted_pages.contains_key(&page_id))
+            .unwrap_or(false)
+        {
+            log(&format!(
+                "Delta: signed page {page_id} was tombstoned before delegate responded — dropping"
+            ));
+            return;
+        }
+    }
+
+    {
         let mut sites = state::SITES.write();
-        if let Some(site) = sites.get_mut(prefix) {
+        if let Some(site) = sites.get_mut(&prefix) {
             site.state.pages.insert(page_id, page.clone());
             if page_id >= site.state.next_page_id {
                 site.state.next_page_id = page_id + 1;
@@ -495,25 +536,30 @@ fn handle_signed_page(page_id: PageId, page: delta_core::Page) {
         }
     }
 
-    // Send UPDATE to network
-    if let Some(contract_key) = pending {
-        let mut updates = BTreeMap::new();
-        updates.insert(page_id, page);
-        let delta = delta_core::SiteStateDelta {
-            config: None,
-            page_updates: updates,
-            page_deletions: Vec::new(),
-        };
-        super::operations::update_site(&contract_key, &delta);
-    }
+    let mut updates = BTreeMap::new();
+    updates.insert(page_id, page);
+    let delta = delta_core::SiteStateDelta {
+        config: None,
+        page_updates: updates,
+        page_deletions: Vec::new(),
+    };
+    super::operations::update_site(&contract_key, &delta);
+
+    // Best-effort cleanup of the legacy correlation map. No longer
+    // load-bearing for routing — see fn doc-comment.
+    PENDING_UPDATES.write().remove(&(prefix, page_id));
 }
 
 /// After receiving a signed config, update local state and send to network.
+/// See `handle_signed_page`'s doc-comment for why routing is via
+/// signature verification rather than `CURRENT_SITE` / `PENDING_CONFIG`.
 fn handle_signed_config(signed_config: delta_core::SignedConfig) {
-    let contract_key = PENDING_CONFIG.write().take();
+    let Some((prefix, contract_key)) = find_owner_for_signed_config(&signed_config) else {
+        log("Delta: signed config doesn't verify against any known owner — dropping");
+        return;
+    };
 
-    // Update local state
-    if let Some(prefix) = state::CURRENT_SITE.read().clone() {
+    {
         let mut sites = state::SITES.write();
         if let Some(site) = sites.get_mut(&prefix) {
             site.state.config = signed_config.clone();
@@ -521,54 +567,99 @@ fn handle_signed_config(signed_config: delta_core::SignedConfig) {
         }
     }
 
-    // Send UPDATE to network
-    if let Some(ck) = contract_key {
-        let delta = delta_core::SiteStateDelta {
-            config: Some(signed_config),
-            page_updates: BTreeMap::new(),
-            page_deletions: Vec::new(),
-        };
-        super::operations::update_site(&ck, &delta);
-    }
+    let delta = delta_core::SiteStateDelta {
+        config: Some(signed_config),
+        page_updates: BTreeMap::new(),
+        page_deletions: Vec::new(),
+    };
+    super::operations::update_site(&contract_key, &delta);
+
+    // Best-effort cleanup of the legacy correlation slot.
+    PENDING_CONFIG.write().take();
+}
+
+/// Find the (prefix, contract_key) for a signed config by checking
+/// its signature against every known owner.
+fn find_owner_for_signed_config(
+    signed: &delta_core::SignedConfig,
+) -> Option<(String, ContractKey)> {
+    let sites = state::SITES.read();
+    sites.iter().find_map(|(prefix, site)| {
+        if signed.verify(&site.state.owner).is_ok() {
+            site.contract_key.map(|ck| (prefix.clone(), ck))
+        } else {
+            None
+        }
+    })
 }
 
 /// After receiving a signed deletion, update local state and send to network.
+/// See `handle_signed_page`'s doc-comment for why routing is via
+/// signature verification rather than `CURRENT_SITE`.
 fn handle_signed_deletion(deletion: delta_core::SignedPageDeletion) {
     let page_id = deletion.page_id;
     log(&format!(
         "Delta: handling signed deletion for page {page_id}"
     ));
-    let pending = PENDING_UPDATES.write().remove(&find_pending_key(page_id));
 
-    let prefix = state::CURRENT_SITE.read().clone();
-    if let Some(prefix) = &prefix {
+    let Some((prefix, contract_key)) = find_owner_for_signed_deletion(&deletion) else {
+        log(&format!(
+            "Delta: signed deletion for {page_id} doesn't verify against any known owner — dropping"
+        ));
+        return;
+    };
+
+    {
         let mut sites = state::SITES.write();
-        if let Some(site) = sites.get_mut(prefix) {
+        if let Some(site) = sites.get_mut(&prefix) {
             site.state.pages.remove(&page_id);
         }
     }
 
-    if let Some(contract_key) = pending {
-        log(&format!(
-            "Delta: sending deletion UPDATE to network for page {page_id}"
-        ));
-        let delta = delta_core::SiteStateDelta {
-            config: None,
-            page_updates: BTreeMap::new(),
-            page_deletions: vec![deletion],
-        };
-        super::operations::update_site(&contract_key, &delta);
-    } else {
-        log(&format!(
-            "Delta: no pending contract key for deletion of page {page_id} - not sent to network"
-        ));
-    }
+    log(&format!(
+        "Delta: sending deletion UPDATE to network for page {page_id}"
+    ));
+    let delta = delta_core::SiteStateDelta {
+        config: None,
+        page_updates: BTreeMap::new(),
+        page_deletions: vec![deletion],
+    };
+    super::operations::update_site(&contract_key, &delta);
+
+    PENDING_UPDATES.write().remove(&(prefix, page_id));
 }
 
-/// Find the pending key for a page_id (searches current site).
-fn find_pending_key(page_id: PageId) -> (String, PageId) {
-    let prefix = state::CURRENT_SITE.read().clone().unwrap_or_default();
-    (prefix, page_id)
+/// Find the (prefix, contract_key) for a signed page by checking its
+/// signature against every known owner. The owner who signed it will
+/// be the only one whose `Page::verify` succeeds.
+fn find_owner_for_signed_page(
+    page: &delta_core::Page,
+    page_id: PageId,
+) -> Option<(String, ContractKey)> {
+    let sites = state::SITES.read();
+    sites.iter().find_map(|(prefix, site)| {
+        if page.verify(page_id, &site.state.owner).is_ok() {
+            site.contract_key.map(|ck| (prefix.clone(), ck))
+        } else {
+            None
+        }
+    })
+}
+
+/// Find the (prefix, contract_key) for a signed deletion. Same
+/// principle as `find_owner_for_signed_page` — only the owner who
+/// signed the deletion will verify it.
+fn find_owner_for_signed_deletion(
+    deletion: &delta_core::SignedPageDeletion,
+) -> Option<(String, ContractKey)> {
+    let sites = state::SITES.read();
+    sites.iter().find_map(|(prefix, site)| {
+        if deletion.verify(&site.state.owner).is_ok() {
+            site.contract_key.map(|ck| (prefix.clone(), ck))
+        } else {
+            None
+        }
+    })
 }
 
 /// Public wrapper so export_key module can send signing-related delegate requests.

--- a/ui/src/state.rs
+++ b/ui/src/state.rs
@@ -439,6 +439,13 @@ pub fn create_page(title: String) {
     let now = now_secs();
     let contract_key = site.contract_key;
     let is_owner = site.role == SiteRole::Owner;
+    // Assign an order strictly greater than any existing page so the
+    // new page sorts after the others. The previous default (0)
+    // caused new pages to land at the front of the sidebar (sort key
+    // is `(order, id)` and 0 dominates any explicit order), and on
+    // refresh the page would be visually relocated to a position the
+    // user did not pick. See issue #15.
+    let next_order = next_create_order(site.state.pages.values().map(|p| p.order));
     drop(sites);
 
     if is_owner {
@@ -451,7 +458,7 @@ pub fn create_page(title: String) {
                 title.clone(),
                 String::new(),
                 now,
-                0,
+                next_order,
             );
             // Optimistically add to local state with placeholder sig
             let mut sites = SITES.write();
@@ -461,7 +468,7 @@ pub fn create_page(title: String) {
                     content: String::new(),
                     updated_at: now,
                     signature: Signature::from_bytes(&[0u8; 64]),
-                    order: 0,
+                    order: next_order,
                 };
                 site.state.pages.insert(id, page);
                 site.state.next_page_id = id + 1;
@@ -475,7 +482,7 @@ pub fn create_page(title: String) {
                     content: String::new(),
                     updated_at: now,
                     signature: Signature::from_bytes(&[0u8; 64]),
-                    order: 0,
+                    order: next_order,
                 };
                 site.state.pages.insert(id, page);
                 site.state.next_page_id = id + 1;
@@ -587,20 +594,66 @@ pub fn rename_page(page_id: PageId, new_title: String) {
 }
 
 /// Swap the order of two pages. Used for move up/down.
-/// Assigns explicit order values to all pages first if they're all 0.
+///
+/// If any page on the site still has `order == 0` (legacy pages signed
+/// before the order field existed, or new pages created before issue
+/// #15 was fixed), this also migrates **every** page to an explicit
+/// order and signs+propagates each one. The local-only fallback used
+/// previously left the unmigrated pages at `order = 0` on the network
+/// so they clumped to the front of the sidebar after a refresh, even
+/// though the local view looked correct. See PR description for the
+/// concrete scenario.
 pub fn swap_page_order(page_a: PageId, page_b: PageId) {
     let Some(prefix) = (*CURRENT_SITE.read()).clone() else {
         return;
+    };
+
+    // Decide whether this swap also has to perform a one-time
+    // order-migration of the whole site. ANY page at `order == 0`
+    // taints the rest because the sidebar sort is `(order, id)` and
+    // 0-ordered pages always sort before pages with explicit orders;
+    // local mutations that don't propagate to the network would be
+    // visually undone on refresh.
+    let needs_migration = SITES
+        .read()
+        .get(&prefix)
+        .map(|s| s.state.pages.values().any(|p| p.order == 0))
+        .unwrap_or(false);
+
+    // Pages that need a fresh signed UPDATE on the network. In the
+    // migration case that's every page on the site (so the network
+    // state actually matches what the user just saw). In the steady
+    // state, only the two pages whose orders changed.
+    let pages_to_sign: Vec<PageId> = if needs_migration {
+        SITES
+            .read()
+            .get(&prefix)
+            .map(|s| s.state.pages.keys().copied().collect())
+            .unwrap_or_default()
+    } else {
+        vec![page_a, page_b]
     };
 
     // Compute the monotonic timestamps before mutating: each call reads
     // the page's *current* `updated_at` so they have to be sampled
     // BEFORE the swap writes new values. See `next_page_updated_at`
     // for why equal timestamps would be dropped on the network.
-    let new_ts_a = next_page_updated_at(&prefix, page_a);
-    let new_ts_b = next_page_updated_at(&prefix, page_b);
+    let new_timestamps: BTreeMap<PageId, u64> = pages_to_sign
+        .iter()
+        .map(|&pid| (pid, next_page_updated_at(&prefix, pid)))
+        .collect();
 
-    // Apply the swap and the new timestamps in a single mutation so
+    // Compute the new order map outside the mutation so the rule is
+    // exercised by `compute_swap_orders` unit tests rather than
+    // re-derived inline here.
+    let current_orders: Vec<(PageId, u32)> = SITES
+        .read()
+        .get(&prefix)
+        .map(|s| s.state.pages.iter().map(|(id, p)| (*id, p.order)).collect())
+        .unwrap_or_default();
+    let new_orders = compute_swap_orders(&current_orders, page_a, page_b);
+
+    // Apply the new orders and timestamps in a single mutation so
     // local state never advertises the new orders alongside the
     // previous timestamps. The signature on disk is still the old one
     // until the delegate echoes back a fresh signed page; that is the
@@ -608,32 +661,22 @@ pub fn swap_page_order(page_a: PageId, page_b: PageId) {
     // which inserts pages with a zeroed signature placeholder).
     SITES.with_mut(|sites| {
         if let Some(site) = sites.get_mut(&prefix) {
-            // If all pages have order 0, assign sequential orders first.
-            let all_zero = site.state.pages.values().all(|p| p.order == 0);
-            if all_zero {
-                let mut sorted: Vec<_> = site.state.pages.keys().copied().collect();
-                sorted.sort();
-                for (i, id) in sorted.iter().enumerate() {
-                    if let Some(p) = site.state.pages.get_mut(id) {
-                        p.order = (i as u32 + 1) * 10;
-                    }
+            for (&pid, &order) in &new_orders {
+                if let Some(p) = site.state.pages.get_mut(&pid) {
+                    p.order = order;
                 }
             }
-
-            let order_a = site.state.pages.get(&page_a).map(|p| p.order).unwrap_or(0);
-            let order_b = site.state.pages.get(&page_b).map(|p| p.order).unwrap_or(0);
-            if let Some(pa) = site.state.pages.get_mut(&page_a) {
-                pa.order = order_b;
-                pa.updated_at = new_ts_a;
-            }
-            if let Some(pb) = site.state.pages.get_mut(&page_b) {
-                pb.order = order_a;
-                pb.updated_at = new_ts_b;
+            for (&pid, &ts) in &new_timestamps {
+                if let Some(p) = site.state.pages.get_mut(&pid) {
+                    p.updated_at = ts;
+                }
             }
         }
     });
 
-    // Order is part of the v2 signature, so re-sign both pages.
+    // Order is part of the v2 signature, so re-sign every page whose
+    // order changed. In the migration case that's all pages; in the
+    // steady state it's just the two pages being swapped.
     let sites = SITES.read();
     let site = match sites.get(&prefix) {
         Some(s) => s,
@@ -643,7 +686,7 @@ pub fn swap_page_order(page_a: PageId, page_b: PageId) {
         Some(ck) => ck,
         None => return,
     };
-    for (pid, ts) in [(page_a, new_ts_a), (page_b, new_ts_b)] {
+    for (&pid, &ts) in &new_timestamps {
         if let Some(page) = site.state.pages.get(&pid) {
             crate::freenet_api::delegate::request_sign_page(
                 &prefix,
@@ -771,6 +814,67 @@ fn monotonic_updated_at(now: u64, existing: Option<u64>) -> u64 {
     }
 }
 
+/// Pick an `order` value for a freshly-created page. The new page
+/// should sort after every existing page so the user-visible position
+/// stays stable across a refresh — issuing `0` (the previous default)
+/// caused new pages to clump at the front of the sidebar because the
+/// sort key is `(order, id)` and 0 dominates any explicit order.
+///
+/// Step is `10` to match `swap_page_order`'s migration so newly
+/// created pages line up on the same grid as migrated ones.
+fn next_create_order<I: IntoIterator<Item = u32>>(existing_orders: I) -> u32 {
+    existing_orders
+        .into_iter()
+        .max()
+        .map(|max| max.saturating_add(10))
+        .unwrap_or(10)
+}
+
+/// Pure helper for `swap_page_order`'s order-assignment step so the
+/// migration + swap logic can be unit-tested without spinning up the
+/// Dioxus signal layer.
+///
+/// Returns the new `order` value for every page on the site after a
+/// swap of `page_a` and `page_b`. If any page is currently at
+/// `order == 0` (legacy / pre-#15 state), the entire site is first
+/// migrated to explicit orders by `(current_order, page_id)` sort key
+/// so the migration preserves the user's visible page sequence; the
+/// swap is then applied on top.
+///
+/// `pages` is the current `(page_id, order)` list. The output is keyed
+/// by page_id so the caller can iterate it independently of input order.
+fn compute_swap_orders(
+    pages: &[(PageId, u32)],
+    page_a: PageId,
+    page_b: PageId,
+) -> BTreeMap<PageId, u32> {
+    let needs_migration = pages.iter().any(|(_, o)| *o == 0);
+
+    let mut next: BTreeMap<PageId, u32> = if needs_migration {
+        // Sort by `(order, id)` — same key the sidebar uses — so the
+        // migration matches what the user is currently looking at.
+        let mut sorted: Vec<(u32, PageId)> = pages.iter().map(|&(id, o)| (o, id)).collect();
+        sorted.sort();
+        sorted
+            .iter()
+            .enumerate()
+            .map(|(i, &(_, id))| (id, (i as u32 + 1) * 10))
+            .collect()
+    } else {
+        pages.iter().copied().collect()
+    };
+
+    let order_a = next.get(&page_a).copied().unwrap_or(0);
+    let order_b = next.get(&page_b).copied().unwrap_or(0);
+    if let Some(o) = next.get_mut(&page_a) {
+        *o = order_b;
+    }
+    if let Some(o) = next.get_mut(&page_b) {
+        *o = order_a;
+    }
+    next
+}
+
 /// Update the browser tab title: "Page — Site — Delta"
 fn update_document_title(site_name: Option<&str>, page_title: Option<&str>) {
     let title = match (page_title, site_name) {
@@ -802,7 +906,9 @@ fn update_hash(hash: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::monotonic_updated_at;
+    use super::{compute_swap_orders, monotonic_updated_at, next_create_order};
+    use delta_core::PageId;
+    use std::collections::BTreeMap;
 
     #[test]
     fn returns_now_for_brand_new_page() {
@@ -852,5 +958,111 @@ mod tests {
         assert!(t2 > t1);
         assert!(t3 > t2);
         assert_eq!((t1, t2, t3), (now + 1, now + 2, now + 3));
+    }
+
+    #[test]
+    fn next_create_order_on_empty_site_starts_at_step() {
+        // First page on a brand-new site gets order=10 instead of 0
+        // so when a SECOND page is created we don't fall into the
+        // "all zero" all-pages-have-the-same-order bucket.
+        assert_eq!(next_create_order(std::iter::empty()), 10);
+    }
+
+    #[test]
+    fn next_create_order_with_zero_only_pages_still_picks_step() {
+        // Legacy v1-signed pages all live at order=0. A new page on
+        // such a site MUST sort after them, so it has to skip past 0.
+        assert_eq!(next_create_order([0, 0, 0]), 10);
+    }
+
+    #[test]
+    fn next_create_order_picks_strictly_greater_than_existing_max() {
+        // Steady-state case: pages have orders 10, 20, 30. New page
+        // gets 40 so it sorts at the end of the sidebar.
+        assert_eq!(next_create_order([10, 20, 30]), 40);
+    }
+
+    #[test]
+    fn next_create_order_handles_unsorted_input() {
+        // Iterator order is whatever BTreeMap::values() produces; the
+        // helper must compute max regardless.
+        assert_eq!(next_create_order([30, 10, 20]), 40);
+    }
+
+    #[test]
+    fn next_create_order_saturates_at_u32_max() {
+        // Pathological — would take >400 million page creations. The
+        // helper must not panic.
+        assert_eq!(next_create_order([u32::MAX]), u32::MAX);
+    }
+
+    fn pages(entries: &[(PageId, u32)]) -> Vec<(PageId, u32)> {
+        entries.to_vec()
+    }
+
+    #[test]
+    fn swap_with_all_explicit_orders_just_swaps_the_two() {
+        // Steady-state: every page has an explicit order. No migration
+        // needed; the swap only touches the two pages clicked.
+        let result = compute_swap_orders(&pages(&[(1, 10), (2, 20), (3, 30)]), 1, 2);
+        let expected: BTreeMap<PageId, u32> = [(1, 20), (2, 10), (3, 30)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn swap_with_all_zero_orders_migrates_every_page() {
+        // The user-reported bug: a site with all legacy pages at
+        // order=0 used to mutate orders only locally. The pure helper
+        // must produce explicit orders for *every* page so the caller
+        // can sign and propagate them all to the network — otherwise
+        // the unmigrated pages stay at 0 on the network and clump to
+        // the front on refresh.
+        let result = compute_swap_orders(&pages(&[(1, 0), (2, 0), (3, 0), (4, 0)]), 1, 2);
+        // Sorted by (order=0, id): 1, 2, 3, 4 -> assigned 10, 20, 30, 40.
+        // Then swap pages 1 and 2: page 1 gets 2's order (20), page 2 gets 1's (10).
+        // Pages 3 and 4 keep their migrated orders.
+        let expected: BTreeMap<PageId, u32> =
+            [(1, 20), (2, 10), (3, 30), (4, 40)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn swap_with_mixed_zero_and_explicit_orders_migrates_everyone() {
+        // After issue #15 was filed but before it was fixed, a site
+        // could have a mix of legacy pages at order=0 and newly-
+        // created pages at order=10/20/.... Migrating only the all-
+        // zero subset would leave the explicit-order pages
+        // overlapping the migrated grid — the helper migrates the
+        // whole site whenever ANY page is still at 0.
+        let result = compute_swap_orders(&pages(&[(1, 0), (2, 0), (3, 10)]), 1, 3);
+        // Sorted by (order, id): (0,1), (0,2), (10,3) -> migrated to
+        // 10, 20, 30 respectively. Then swap pages 1 and 3: page 1
+        // gets 30, page 3 gets 10.
+        let expected: BTreeMap<PageId, u32> = [(1, 30), (2, 20), (3, 10)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn migration_sort_key_matches_sidebar_sort_key() {
+        // The sidebar sorts pages by `(order, id)`. The migration must
+        // use the same key so the post-migration sequence visually
+        // matches what the user clicked. Here pages 5 and 1 share
+        // order=0 — the sort tiebreaker by id puts 1 before 5.
+        let result = compute_swap_orders(&pages(&[(5, 0), (1, 0), (3, 5)]), 5, 1);
+        // Sorted: (0,1), (0,5), (5,3) -> migrated 10, 20, 30.
+        // Then swap pages 5 and 1: page 5 (was 20) gets 10, page 1
+        // (was 10) gets 20.
+        let expected: BTreeMap<PageId, u32> = [(1, 20), (5, 10), (3, 30)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn swap_is_a_no_op_when_pages_share_an_order_after_migration() {
+        // Defensive: if both swap targets happen to land on the same
+        // migrated order (impossible in normal flow but cheap to
+        // pin), the result is a no-op rather than corruption.
+        let result = compute_swap_orders(&pages(&[(1, 10), (2, 10), (3, 30)]), 1, 2);
+        let expected: BTreeMap<PageId, u32> = [(1, 10), (2, 10), (3, 30)].into_iter().collect();
+        assert_eq!(result, expected);
     }
 }

--- a/ui/src/state.rs
+++ b/ui/src/state.rs
@@ -608,50 +608,51 @@ pub fn swap_page_order(page_a: PageId, page_b: PageId) {
         return;
     };
 
-    // Decide whether this swap also has to perform a one-time
-    // order-migration of the whole site. ANY page at `order == 0`
-    // taints the rest because the sidebar sort is `(order, id)` and
-    // 0-ordered pages always sort before pages with explicit orders;
-    // local mutations that don't propagate to the network would be
-    // visually undone on refresh.
-    let needs_migration = SITES
-        .read()
-        .get(&prefix)
-        .map(|s| s.state.pages.values().any(|p| p.order == 0))
-        .unwrap_or(false);
-
-    // Pages that need a fresh signed UPDATE on the network. In the
-    // migration case that's every page on the site (so the network
-    // state actually matches what the user just saw). In the steady
-    // state, only the two pages whose orders changed.
-    let pages_to_sign: Vec<PageId> = if needs_migration {
-        SITES
-            .read()
-            .get(&prefix)
-            .map(|s| s.state.pages.keys().copied().collect())
-            .unwrap_or_default()
-    } else {
-        vec![page_a, page_b]
+    // Single read-pass: collect everything the orchestration needs in
+    // one shot so we don't race with a network UPDATE landing between
+    // independent `SITES.read()` calls. (Single-threaded UI in
+    // practice, but cheaper to be obviously correct than to argue
+    // about it in a future refactor.)
+    let (current_orders, current_timestamps, contract_key) = {
+        let sites = SITES.read();
+        let Some(site) = sites.get(&prefix) else {
+            return;
+        };
+        let orders: Vec<(PageId, u32)> = site
+            .state
+            .pages
+            .iter()
+            .map(|(id, p)| (*id, p.order))
+            .collect();
+        let timestamps: BTreeMap<PageId, u64> = site
+            .state
+            .pages
+            .iter()
+            .map(|(id, p)| (*id, p.updated_at))
+            .collect();
+        (orders, timestamps, site.contract_key)
+    };
+    let Some(contract_key) = contract_key else {
+        return;
     };
 
-    // Compute the monotonic timestamps before mutating: each call reads
-    // the page's *current* `updated_at` so they have to be sampled
-    // BEFORE the swap writes new values. See `next_page_updated_at`
-    // for why equal timestamps would be dropped on the network.
-    let new_timestamps: BTreeMap<PageId, u64> = pages_to_sign
-        .iter()
-        .map(|&pid| (pid, next_page_updated_at(&prefix, pid)))
-        .collect();
+    let plan = plan_swap(&current_orders, page_a, page_b);
+    if plan.pages_to_sign.is_empty() {
+        return; // No-op: same-order swap, missing pages, etc.
+    }
 
-    // Compute the new order map outside the mutation so the rule is
-    // exercised by `compute_swap_orders` unit tests rather than
-    // re-derived inline here.
-    let current_orders: Vec<(PageId, u32)> = SITES
-        .read()
-        .get(&prefix)
-        .map(|s| s.state.pages.iter().map(|(id, p)| (*id, p.order)).collect())
-        .unwrap_or_default();
-    let new_orders = compute_swap_orders(&current_orders, page_a, page_b);
+    // Strict-monotonic timestamp per page, derived from the snapshot
+    // taken above so all pages observe the same `now` and the same
+    // existing values.
+    let now = now_secs();
+    let new_timestamps: BTreeMap<PageId, u64> = plan
+        .pages_to_sign
+        .iter()
+        .map(|&pid| {
+            let ts = monotonic_updated_at(now, current_timestamps.get(&pid).copied());
+            (pid, ts)
+        })
+        .collect();
 
     // Apply the new orders and timestamps in a single mutation so
     // local state never advertises the new orders alongside the
@@ -661,7 +662,7 @@ pub fn swap_page_order(page_a: PageId, page_b: PageId) {
     // which inserts pages with a zeroed signature placeholder).
     SITES.with_mut(|sites| {
         if let Some(site) = sites.get_mut(&prefix) {
-            for (&pid, &order) in &new_orders {
+            for (&pid, &order) in &plan.new_orders {
                 if let Some(p) = site.state.pages.get_mut(&pid) {
                     p.order = order;
                 }
@@ -678,16 +679,11 @@ pub fn swap_page_order(page_a: PageId, page_b: PageId) {
     // order changed. In the migration case that's all pages; in the
     // steady state it's just the two pages being swapped.
     let sites = SITES.read();
-    let site = match sites.get(&prefix) {
-        Some(s) => s,
-        None => return,
+    let Some(site) = sites.get(&prefix) else {
+        return;
     };
-    let contract_key = match site.contract_key {
-        Some(ck) => ck,
-        None => return,
-    };
-    for (&pid, &ts) in &new_timestamps {
-        if let Some(page) = site.state.pages.get(&pid) {
+    for &pid in &plan.pages_to_sign {
+        if let (Some(page), Some(&ts)) = (site.state.pages.get(&pid), new_timestamps.get(&pid)) {
             crate::freenet_api::delegate::request_sign_page(
                 &prefix,
                 contract_key,
@@ -814,20 +810,70 @@ fn monotonic_updated_at(now: u64, existing: Option<u64>) -> u64 {
     }
 }
 
+/// Step between page orders. Used by both `next_create_order` and the
+/// migration in `compute_swap_orders` so newly-created pages and
+/// migrated pages share the same grid (pages with explicit orders
+/// `10, 20, 30, ...` and a fresh page slotted in at `40`).
+const ORDER_STEP: u32 = 10;
+
 /// Pick an `order` value for a freshly-created page. The new page
 /// should sort after every existing page so the user-visible position
 /// stays stable across a refresh — issuing `0` (the previous default)
 /// caused new pages to clump at the front of the sidebar because the
 /// sort key is `(order, id)` and 0 dominates any explicit order.
-///
-/// Step is `10` to match `swap_page_order`'s migration so newly
-/// created pages line up on the same grid as migrated ones.
 fn next_create_order<I: IntoIterator<Item = u32>>(existing_orders: I) -> u32 {
     existing_orders
         .into_iter()
         .max()
-        .map(|max| max.saturating_add(10))
-        .unwrap_or(10)
+        .map(|max| max.saturating_add(ORDER_STEP))
+        .unwrap_or(ORDER_STEP)
+}
+
+/// What `swap_page_order` is going to do, computed without touching
+/// the live signal state. Returned by `plan_swap` so the orchestration
+/// rule (which pages need a fresh signature, which orders they end up
+/// with) is unit-testable end-to-end, not just at the `compute_swap_orders`
+/// step.
+#[derive(Debug, PartialEq, Eq)]
+struct SwapPlan {
+    /// New `order` value for every page on the site, keyed by
+    /// `PageId`. Pages whose order didn't change still appear here
+    /// (with their existing value) so callers don't have to merge.
+    new_orders: BTreeMap<PageId, u32>,
+    /// Pages that need a fresh signed UPDATE on the network — i.e.
+    /// whose order actually changed. Empty when the swap is a no-op
+    /// (e.g. both pages had the same order, or the swap target IDs
+    /// don't exist in `pages`).
+    pages_to_sign: Vec<PageId>,
+}
+
+/// Plan a swap end-to-end: compute the new orders AND the set of
+/// pages whose UPDATEs must be propagated to the network. Pure helper
+/// so the user-visible "every page must be signed when migrating"
+/// invariant is exercised by unit tests, not just at the
+/// `compute_swap_orders` boundary.
+fn plan_swap(pages: &[(PageId, u32)], page_a: PageId, page_b: PageId) -> SwapPlan {
+    let new_orders = compute_swap_orders(pages, page_a, page_b);
+    // Pages-to-sign = pages whose new order differs from current.
+    // In the migration case that's every page on the site; in steady
+    // state it's just the two pages being swapped. Deriving from the
+    // diff means a regression that re-narrows the migration set
+    // (e.g. someone reverts to "just the two clicked pages") is
+    // automatically caught.
+    let pages_to_sign: Vec<PageId> = pages
+        .iter()
+        .filter_map(|&(pid, current)| {
+            new_orders
+                .get(&pid)
+                .copied()
+                .filter(|&new| new != current)
+                .map(|_| pid)
+        })
+        .collect();
+    SwapPlan {
+        new_orders,
+        pages_to_sign,
+    }
 }
 
 /// Pure helper for `swap_page_order`'s order-assignment step so the
@@ -842,7 +888,10 @@ fn next_create_order<I: IntoIterator<Item = u32>>(existing_orders: I) -> u32 {
 /// swap is then applied on top.
 ///
 /// `pages` is the current `(page_id, order)` list. The output is keyed
-/// by page_id so the caller can iterate it independently of input order.
+/// by page_id so the caller can iterate it independently of input
+/// order. If either swap target is not present in `pages` the swap
+/// is skipped — the helper is otherwise a foot-gun that would clobber
+/// the present page's order to 0 via `unwrap_or(0)`.
 fn compute_swap_orders(
     pages: &[(PageId, u32)],
     page_a: PageId,
@@ -858,19 +907,23 @@ fn compute_swap_orders(
         sorted
             .iter()
             .enumerate()
-            .map(|(i, &(_, id))| (id, (i as u32 + 1) * 10))
+            .map(|(i, &(_, id))| (id, (i as u32 + 1) * ORDER_STEP))
             .collect()
     } else {
         pages.iter().copied().collect()
     };
 
-    let order_a = next.get(&page_a).copied().unwrap_or(0);
-    let order_b = next.get(&page_b).copied().unwrap_or(0);
-    if let Some(o) = next.get_mut(&page_a) {
-        *o = order_b;
-    }
-    if let Some(o) = next.get_mut(&page_b) {
-        *o = order_a;
+    // Skip the swap if either target is missing. Without this guard
+    // `unwrap_or(0)` clobbers the present page's order to 0,
+    // re-introducing the very symptom this PR is fixing.
+    if let (Some(order_a), Some(order_b)) = (next.get(&page_a).copied(), next.get(&page_b).copied())
+    {
+        if let Some(o) = next.get_mut(&page_a) {
+            *o = order_b;
+        }
+        if let Some(o) = next.get_mut(&page_b) {
+            *o = order_a;
+        }
     }
     next
 }
@@ -906,7 +959,7 @@ fn update_hash(hash: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_swap_orders, monotonic_updated_at, next_create_order};
+    use super::{compute_swap_orders, monotonic_updated_at, next_create_order, plan_swap};
     use delta_core::PageId;
     use std::collections::BTreeMap;
 
@@ -1064,5 +1117,112 @@ mod tests {
         let result = compute_swap_orders(&pages(&[(1, 10), (2, 10), (3, 30)]), 1, 2);
         let expected: BTreeMap<PageId, u32> = [(1, 10), (2, 10), (3, 30)].into_iter().collect();
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn swap_skips_when_target_id_not_in_pages() {
+        // Prior implementation called `unwrap_or(0)` on the missing
+        // target's order and clobbered the present page's order to
+        // 0 — re-introducing the very symptom this PR is fixing.
+        let result = compute_swap_orders(&pages(&[(1, 10), (2, 20)]), 1, 999);
+        let expected: BTreeMap<PageId, u32> = [(1, 10), (2, 20)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn swap_skips_when_neither_target_id_in_pages() {
+        let result = compute_swap_orders(&pages(&[(1, 10), (2, 20)]), 998, 999);
+        let expected: BTreeMap<PageId, u32> = [(1, 10), (2, 20)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn swap_with_empty_pages_returns_empty() {
+        let result = compute_swap_orders(&pages(&[]), 1, 2);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn self_swap_is_a_no_op() {
+        // Sidebar arrow handler can't trigger this (it always picks a
+        // distinct neighbor) but defend the helper anyway.
+        let result = compute_swap_orders(&pages(&[(1, 10), (2, 20)]), 1, 1);
+        let expected: BTreeMap<PageId, u32> = [(1, 10), (2, 20)].into_iter().collect();
+        assert_eq!(result, expected);
+    }
+
+    // -- plan_swap orchestration tests --
+    //
+    // These pin the user-visible "every page must be signed when
+    // migrating" rule end-to-end. A regression that re-narrows
+    // `pages_to_sign` (e.g. back to `vec![page_a, page_b]`) is caught
+    // by these tests, not just by the lower-level
+    // `compute_swap_orders` tests.
+
+    #[test]
+    fn plan_swap_in_steady_state_signs_only_the_two_clicked_pages() {
+        // Site already migrated, every page has explicit orders. The
+        // swap should only require fresh signatures for the pages
+        // whose orders actually changed.
+        let plan = plan_swap(&pages(&[(1, 10), (2, 20), (3, 30)]), 1, 2);
+        assert_eq!(plan.pages_to_sign.to_vec(), vec![1, 2]);
+        let expected_orders: BTreeMap<PageId, u32> =
+            [(1, 20), (2, 10), (3, 30)].into_iter().collect();
+        assert_eq!(plan.new_orders, expected_orders);
+    }
+
+    #[test]
+    fn plan_swap_in_migration_signs_every_page_on_the_site() {
+        // The user-reported bug: previously only the two clicked
+        // pages got UPDATEs sent to the network. The other pages
+        // stayed at order=0 on the network and clumped to the front
+        // of the sidebar after a refresh. `plan_swap` must include
+        // every page in `pages_to_sign` whenever migration fires.
+        let plan = plan_swap(&pages(&[(1, 0), (2, 0), (3, 0), (4, 0)]), 1, 2);
+        let mut signed = plan.pages_to_sign.clone();
+        signed.sort();
+        assert_eq!(signed, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn plan_swap_in_mixed_state_signs_every_page() {
+        // Mixed-state site: some pages migrated to explicit orders,
+        // some still at 0 (the symptom #15 left behind even after
+        // PR #13's `updated_at` fix). Migration must fire and sign
+        // every page on the site.
+        let plan = plan_swap(&pages(&[(1, 0), (2, 10), (3, 0)]), 1, 3);
+        let mut signed = plan.pages_to_sign.clone();
+        signed.sort();
+        assert_eq!(signed, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn plan_swap_is_idempotent_after_a_migration_round() {
+        // After the first reorder migrates the site, the second
+        // reorder must NOT migrate again — it should just swap the
+        // two clicked pages. Without this, every reorder on a
+        // formerly-zero-order site would re-sign every page forever.
+        let migrated = pages(&[(1, 20), (2, 10), (3, 30), (4, 40)]); // post-first-swap
+        let plan = plan_swap(&migrated, 3, 4);
+        let mut signed = plan.pages_to_sign.clone();
+        signed.sort();
+        assert_eq!(signed, vec![3, 4]);
+    }
+
+    #[test]
+    fn plan_swap_returns_empty_pages_to_sign_when_swap_is_a_no_op() {
+        // No page changed order -> nothing needs signing. The
+        // orchestrator uses this signal to skip the network round-
+        // trip entirely.
+        let plan = plan_swap(&pages(&[(1, 10), (2, 10)]), 1, 2);
+        assert!(plan.pages_to_sign.is_empty());
+    }
+
+    #[test]
+    fn plan_swap_returns_empty_pages_to_sign_when_target_missing() {
+        // Same skip behaviour for missing swap targets — the
+        // orchestrator treats this as a no-op.
+        let plan = plan_swap(&pages(&[(1, 10), (2, 20)]), 1, 999);
+        assert!(plan.pages_to_sign.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

Reordering pages in Delta still didn't stick across a refresh after PR #13. Ivvor reported: *"some do and some just don't reorder, let alone stick"* (Matrix, 2026-05-03). Steady-state swaps work, but as soon as the site has any page at `order = 0` the user-visible reorder doesn't survive a GET.

## Root cause (two bugs in the reorder path, three more uncovered by review)

**The reorder bug itself — two causes the user re-reported:**

1. **`swap_page_order` migration was local-only.** The "if all pages have order=0, assign sequential orders first" branch mutated *local* state. `request_sign_page` was then called for the two clicked pages only, so just those two got an UPDATE on the network. Every other page kept `order = 0` on the network. On refresh, the sidebar sort key `(order, id)` puts all the order=0 pages in front of the two pages with explicit orders — visually the reorder appeared to be undone, with extra pages reshuffled to the front.

2. **`create_page` always assigned `order = 0`.** A single fresh page re-poisoned an otherwise-migrated site. Filed as #15 after PR #13's review and never fixed.

PR #13 fixed the `updated_at` half of the same symptom (commit `cafcc42`) but left both order-related causes in place.

**Three pre-existing race conditions in the delegate-signing pipeline that the migration amplifies (50 in-flight signed pages instead of 2):**

3. **`PENDING_UPDATES` collision.** Keyed by `(prefix, page_id)`. Two in-flight requests for the same page shared a single entry; the first response consumed it, the second silently dropped its network UPDATE.

4. **`find_pending_key` read `CURRENT_SITE`**, not the prefix the request was sent for. A mid-flight site switch routed late-arriving signed pages into the wrong site's local state.

5. **Tombstone overwrite race.** `handle_signed_page` unconditionally re-inserted a signed page into local state even if `delete_page` had tombstoned it in the meantime.

## Approach

**`swap_page_order`:**

- Trigger the order-migration whenever ANY page on the site has `order = 0` (not only when *all* are 0). Covers the mixed-state case introduced by #15 and is idempotent once migrated.
- Sort the migration by `(order, id)` — matching the sidebar sort key — so the user-visible page sequence is preserved.
- Sign and propagate every page whose order changes, not just the two clicked. Pages-to-sign is derived from the diff between current and new orders, so a regression that re-narrows the sign set is caught by orchestration tests.
- Single-pass `SITES.read()` collects orders + timestamps + contract_key in one acquisition.
- Extracted into pure helpers `plan_swap` (orchestration) and `compute_swap_orders` (order assignment) for unit-testing without the Dioxus signal layer.
- Hardened `compute_swap_orders` against missing swap targets — the previous `unwrap_or(0)` clobbered the present page's order to 0 if the other target wasn't in the list (re-introducing the very symptom this PR is fixing).

**`create_page`:**

- Assign `order = max(existing) + ORDER_STEP` (10 for the first page) via `next_create_order`. Closes #15.
- Shared `const ORDER_STEP: u32 = 10` so the migration grid and `next_create_order`'s step can't drift apart.

**Delegate-response routing rewrite:**

- `handle_signed_page` / `handle_signed_deletion` / `handle_signed_config` now derive the owning site from the signature itself (`Page::verify` against every known owner pubkey; only the actual signer verifies). No reliance on `CURRENT_SITE` or `PENDING_UPDATES`.
- `handle_signed_page` checks `deleted_pages` before re-inserting, so a late signed page response that lost the race with `delete_page` is dropped instead of resurrecting the page.
- No delegate WASM change required — same response format, smarter routing.

**AGENTS.md:** pin three new invariants alongside the strict-monotonic `updated_at` paragraph (every-page-signed migration, `next_create_order` mandatory, signature-based response routing).

## Testing

- 5 tests for `next_create_order`: empty site, all-zero site, steady-state, unsorted input, u32::MAX saturation.
- 5 tests for `compute_swap_orders` core: steady-state swap, all-zero migration, mixed zero/explicit migration, sort-key matches sidebar, defensive same-order no-op.
- 4 tests for `compute_swap_orders` edge cases: missing target, both targets missing, empty pages, self-swap.
- 6 tests for `plan_swap` orchestration: steady-state signs only two, migration signs every page, mixed state signs every page, idempotency after first migration, no-op same-order, no-op missing target.

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --workspace` green (57 delta-ui tests, 21 delta-core tests). `cargo check --target wasm32-unknown-unknown` green.

No contract or delegate WASM changes — this is a UI-only fix, no migration entries needed.

## Related issues

- Closes #15 (create_page should assign order = max + 1).
- Mitigates #14 (rapid-reorder drift): the migration step is bounded by page count, one-time per site.
- Filed #18 for the contract-side tombstone gap (apply_delta needs the same check `merge` already has) — that fix needs a contract WASM migration so it stays out of this PR.

[AI-assisted - Claude]