### PR TITLE
fix(ui): respect GFM table column alignment

### DIFF
--- a/ui/assets/tailwind.css
+++ b/ui/assets/tailwind.css
@@ -294,6 +294,14 @@ html, body {
   text-align: left;
   font-size: 0.9375em;
 }
+/* GFM table column alignment. The `markdown` crate emits the
+ * deprecated `align="left|center|right"` HTML attribute on `<th>` /
+ * `<td>` for `| :--- |`, `| :---: |`, `| ---: |` separator rows.
+ * Modern browsers don't always honor that attribute when CSS sets
+ * `text-align`, so map it explicitly. */
+.prose th[align="left"], .prose td[align="left"] { text-align: left; }
+.prose th[align="center"], .prose td[align="center"] { text-align: center; }
+.prose th[align="right"], .prose td[align="right"] { text-align: right; }
 .prose th {
   background-color: var(--color-panel-warm);
   font-weight: 600;


### PR DESCRIPTION
## Problem

Markdown table column alignment (`| :--- |`, `| :---: |`, `| ---: |`) didn't render. Reported by Ivvor (Matrix, 2026-05-03).

The `markdown` crate emits the GFM-conformant `align="left|center|right"` HTML attribute on `<th>` / `<td>`, but `.prose th, .prose td` in `ui/assets/tailwind.css` had a blanket `text-align: left;` rule that overrode the inline attribute (`align="..."` is a deprecated HTML attribute and CSS specificity wins over it).

## Solution

Map the `[align="..."]` attribute selector to `text-align` so the column-alignment annotation actually takes effect. The default left-align is preserved for tables without alignment markers.

## Testing

Manual: rebuild the Tailwind output and verify a 3-column table with `| :--- | :---: | ---: |` renders left/center/right correctly. CSS-only change; no Rust tests apply.

[AI-assisted - Claude]