### PR TITLE
fix(ui): self-clear stuck Error indicator on next response

### DIFF
--- a/ui/src/freenet_api/operations.rs
+++ b/ui/src/freenet_api/operations.rs
@@ -120,6 +120,17 @@ pub(crate) fn classify_get_response(
 
 /// Handle an incoming response from the Freenet node.
 pub fn handle_response(response: HostResponse) {
+    // Receiving a response means the WebSocket is still alive.
+    // Self-clear a stuck `ConnectionStatus::Error` so the bottom-left
+    // indicator doesn't stay red forever after a transient transport
+    // blip — the WebApi error callback that originally set it has no
+    // counterpart that resets the status. (Ivvor, 2026-05-03)
+    let mut status = super::CONNECTION_STATUS.write();
+    if !matches!(&*status, super::ConnectionStatus::Connected) {
+        *status = super::ConnectionStatus::Connected;
+    }
+    drop(status);
+
     match response {
         HostResponse::ContractResponse(contract_response) => {
             handle_contract_response(contract_response);


### PR DESCRIPTION
## Problem

Ivvor (Matrix, 2026-05-03 11:25):

> Using in-page links still cause the Error warning and the red dot in bottom left of page, despite working

Once \`ConnectionStatus\` flips to \`Error\`, nothing in the codebase resets it back to \`Connected\` — the WebApi error callback in \`connection.rs\` writes \`Error\` but the response-handler path doesn't have a counterpart write. So a single transient WebSocket blip leaves the indicator stuck red until the user reloads the iframe, even when subsequent operations are landing fine and the connection is healthy.

The \"despite working\" observation is the giveaway: navigation works, so the WebSocket clearly recovered, but the indicator hasn't caught up.

## Approach

Receiving any successful response from the node is concrete proof the WebSocket is alive. \`handle_response\` now flips the status back to \`Connected\` if it isn't already, so the indicator self-clears on the next message.

## Caveats

This doesn't fix the underlying transport blip — that's still an open question. PR #23 likely reduces the rate of accidental new-tab opens (which probably contributes to background-tab WebSocket drops). But this fix is the right behavior regardless: the indicator should reflect *current* connectivity, not the worst state we've ever observed.

## Testing

\`cargo fmt --check\` clean, \`cargo clippy --all-targets -- -D warnings\` clean, \`cargo test -p delta-ui\` green (113 tests, no new), \`cargo check --target wasm32-unknown-unknown\` green.

No new tests because this hooks into the live WebApi response callback which can't be exercised without standing up the runtime; the change is small enough (one block at a known callsite) that visual review covers it.

[AI-assisted - Claude]