### PR TITLE
fix(ui): accept relative same-contract URLs + reconnect on WS close

### DIFF
--- a/ui/src/components/page_view.rs
+++ b/ui/src/components/page_view.rs
@@ -391,14 +391,25 @@ struct FreenetWebUrl<'a> {
 /// into `/foo` on the reader's local gateway, redirecting the click to
 /// the victim's gateway instead of the attacker's host.
 fn parse_freenet_web_url(url: &str) -> Option<FreenetWebUrl<'_>> {
-    let scheme_end = url.find("://")?;
-    let scheme = &url[..scheme_end];
-    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+    // Either an absolute URL (http://host/v1/contract/web/...) or a
+    // path-relative URL (/v1/contract/web/...) — both are valid in
+    // user-authored markdown. Ivvor 2026-05-03 12:10 reported using
+    // the relative form; without this the relative href slipped past
+    // same-contract detection and got `target="_blank"` despite
+    // pointing at our own contract.
+    let path = if let Some(scheme_end) = url.find("://") {
+        let scheme = &url[..scheme_end];
+        if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+            return None;
+        }
+        let after_scheme = &url[scheme_end + 3..];
+        let path_offset = after_scheme.find('/')?;
+        &after_scheme[path_offset..]
+    } else if url.starts_with('/') {
+        url
+    } else {
         return None;
-    }
-    let after_scheme = &url[scheme_end + 3..];
-    let path_offset = after_scheme.find('/')?;
-    let path = &after_scheme[path_offset..];
+    };
     let after_marker = path.strip_prefix("/v1/contract/web/")?;
 
     let id_end = after_marker
@@ -1201,6 +1212,53 @@ mod tests {
             result.contains(">freenet:raAqMhMG/?a=1&amp;b=2</a>"),
             "expected beautified label with `&amp;amp;` preserved; got: {result}"
         );
+    }
+
+    #[test]
+    fn parse_freenet_web_url_accepts_relative_path() {
+        // Ivvor 2026-05-03 12:10: `[David's Place](/v1/contract/web/<id>/#prefix/page/about)`
+        // — relative-path markdown link (no scheme/host). Without
+        // this, the relative href fell through `parse_freenet_web_url`,
+        // missed the same-contract check, and got `target="_blank"`.
+        let url = format!("/v1/contract/web/{DELTA_ID}/#Fe5jaFmRnp/1/about");
+        let parsed = parse_freenet_web_url(&url).expect("relative URL should parse");
+        assert_eq!(parsed.contract_id, DELTA_ID);
+        assert_eq!(parsed.suffix, "/#Fe5jaFmRnp/1/about");
+        assert_eq!(parsed.absolute_path, url);
+    }
+
+    #[test]
+    fn parse_freenet_web_url_rejects_path_relative_non_contract() {
+        // Path-relative URL that doesn't hit the marker is not a
+        // Freenet URL.
+        assert!(parse_freenet_web_url("/some/other/path").is_none());
+        assert!(parse_freenet_web_url("/v1/contract/web/").is_none());
+    }
+
+    #[test]
+    fn parse_freenet_web_url_rejects_unrooted_path_without_scheme() {
+        // No scheme AND no leading `/` — could be a fragment, a
+        // relative path, anything. Don't try to parse.
+        assert!(parse_freenet_web_url("v1/contract/web/abc").is_none());
+        assert!(parse_freenet_web_url("foo").is_none());
+    }
+
+    #[test]
+    fn finalize_anchors_treats_relative_same_contract_url_as_internal() {
+        // The exact reproduction of Ivvor's case: relative-path
+        // markdown link to the same contract. Must not get
+        // `target="_blank"` and must keep the relative href intact.
+        let html = format!(
+            "<a href=\"/v1/contract/web/{DELTA_ID}/#Fe5jaFmRnp/1/about\">David's Place</a>"
+        );
+        let result = finalize_anchors(&html, true, Some(DELTA_ID));
+        assert!(
+            !result.contains("target=\"_blank\""),
+            "relative same-contract URL must not get target=_blank: {result}"
+        );
+        assert!(result.contains(&format!(
+            "href=\"/v1/contract/web/{DELTA_ID}/#Fe5jaFmRnp/1/about\""
+        )));
     }
 
     #[test]

--- a/ui/src/freenet_api/connection.rs
+++ b/ui/src/freenet_api/connection.rs
@@ -19,6 +19,48 @@ pub enum ConnectionStatus {
     Error(String),
 }
 
+/// Whether a reconnect attempt is already scheduled. Prevents the
+/// error callback from queueing multiple parallel reconnects when
+/// it fires more than once during a teardown.
+#[cfg(target_arch = "wasm32")]
+static RECONNECT_PENDING: GlobalSignal<bool> = GlobalSignal::new(|| false);
+
+/// Schedule a `connect_to_freenet()` retry after a 2 s delay. Called
+/// from the error callback when the WebSocket closes — without this,
+/// the iframe stays in `Error` state until the user refreshes,
+/// because nothing in the codebase reopens a closed WebSocket.
+#[cfg(target_arch = "wasm32")]
+fn schedule_reconnect() {
+    if *RECONNECT_PENDING.read() {
+        return;
+    }
+    *RECONNECT_PENDING.write() = true;
+
+    use wasm_bindgen::prelude::*;
+    let cb = Closure::<dyn Fn()>::new(|| {
+        *RECONNECT_PENDING.write() = false;
+        // Skip if the user has already manually reconnected (e.g.
+        // by triggering a hash navigation that fires
+        // connect_to_freenet) — `Connecting` and `Connected` both
+        // mean we don't want to clobber a fresh socket.
+        if matches!(
+            &*CONNECTION_STATUS.read(),
+            ConnectionStatus::Connected | ConnectionStatus::Connecting
+        ) {
+            return;
+        }
+        web_sys::console::log_1(&"Delta: attempting WebSocket reconnect".into());
+        connect_to_freenet();
+    });
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            cb.as_ref().unchecked_ref(),
+            2_000,
+        );
+    }
+    cb.forget();
+}
+
 /// Connect to the Freenet node's WebSocket API.
 pub fn connect_to_freenet() {
     #[cfg(target_arch = "wasm32")]
@@ -71,6 +113,14 @@ pub fn connect_to_freenet() {
                 web_sys::console::error_1(&truncated.into());
                 *CONNECTION_STATUS.write() =
                     ConnectionStatus::Error("Connection failed".to_string());
+                // Schedule a reconnect attempt. Without this, the
+                // WebSocket stays dead until the user refreshes the
+                // iframe — which is what surfaced as Ivvor's "red
+                // Error indicator" 2026-05-03 12:20 ("WebSocket
+                // connection closed" + "{error:'connection closed'}"
+                // in the console). Backed off to 2 s so a flapping
+                // node doesn't trigger a tight retry loop.
+                schedule_reconnect();
             },
             move || {
                 web_sys::console::log_1(&"Delta: connected to Freenet".into());


### PR DESCRIPTION
## Two bugs from Ivvor's 12:10 / 12:20 diagnostics

### 1. Relative same-contract URLs still got new tabs

The link \`[David's Place](/v1/contract/web/<id>/#prefix/page/about)\` is a path-relative markdown link — no scheme, no host. PR #23's \`parse_freenet_web_url\` required \`://\`, so the relative href fell through the same-contract check, got classified as external, and got \`target="_blank"\`.

The parser now accepts paths starting with \`/\` directly, in addition to absolute http(s) URLs. Same contract-ID extraction and same dotdot guard apply.

### 2. WebSocket close left the iframe stuck in Error

Browser console when clicking the \`http://localhost:7509/v1/contract/web/<id>/#...\` form (cross-origin from the iframe's \`127.0.0.1:7509\`):

\`\`\`
WebSocket connection closed
Delta: connection error: request error: {"error":"connection closed","source":"close"}
\`\`\`

The cross-origin click reloaded the iframe, killing the old WebSocket. The error callback set \`ConnectionStatus::Error\` — but nothing in the codebase reopened the socket, so the red indicator stayed until manual refresh. PR #24's self-clear-on-next-response can't help because no responses arrive on a closed socket.

The error callback now schedules a reconnect via \`setTimeout\` (2 s back-off). A \`RECONNECT_PENDING\` flag guards against the error firing multiple times during teardown and queueing parallel reconnects. The scheduled callback skips itself if the user has already manually reconnected (Status is now \`Connected\` or \`Connecting\`).

## Testing

4 new tests for the relative-URL parser: accepts the exact form Ivvor used; rejects relative paths that don't hit the marker; rejects unrooted paths (no scheme AND no leading \`/\`); \`finalize_anchors\` treats relative same-contract URLs as internal (no target=_blank, href untouched).

The reconnect path can't be unit-tested without standing up the WASM runtime; visual review covers the flag-based debounce.

\`cargo fmt --check\` clean, \`cargo clippy --all-targets -- -D warnings\` clean, \`cargo test -p delta-ui page_view\` green (50 tests, 4 new), \`cargo check --target wasm32-unknown-unknown\` green.

[AI-assisted - Claude]