### PR TITLE
fix(page_view): keep rename dialog open during text-selection drag

### DIFF
--- a/ui/src/components/page_view.rs
+++ b/ui/src/components/page_view.rs
@@ -138,9 +138,21 @@ pub fn PageView() -> Element {
         if *renaming.read() {
             div {
                 style: "position: absolute; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 50;",
-                onclick: move |_| renaming.set(false),
+                // Close on `mousedown` rather than `click`. With `click`,
+                // a text-selection drag that starts inside the dialog
+                // and releases outside fires `click` on the backdrop
+                // (the nearest common ancestor of mousedown's input
+                // target and mouseup's backdrop target) and dismisses
+                // the dialog mid-selection. Issue #26.
+                onmousedown: move |_| renaming.set(false),
                 div {
                     class: "bg-panel rounded-xl shadow-lg w-80 p-5",
+                    // Stop the mousedown from reaching the backdrop so
+                    // text-selection inside the dialog never triggers
+                    // dismissal. The `onclick` handler is kept for
+                    // belt-and-braces safety against any future caller
+                    // re-adding onclick on the backdrop.
+                    onmousedown: move |evt| evt.stop_propagation(),
                     onclick: move |evt| evt.stop_propagation(),
                     h3 { class: "text-sm font-semibold text-text mb-3", "Rename Page" }
                     input {


### PR DESCRIPTION
## Problem

#26: when the Rename Page modal is open and the user starts a text selection inside the dialog and releases the mouse outside, the dialog closes mid-selection.

The cause is the backdrop's \`onclick\` handler. The \`click\` event fires on the nearest common ancestor of \`mousedown\`'s target (the input) and \`mouseup\`'s target (the backdrop), which is the backdrop itself — and \`stop_propagation\` on the inner div only catches \`click\` events whose target is inside the inner div, not events that bubble from the common ancestor outward.

## Solution

Close the modal on \`mousedown\` instead of \`click\`, and stop both \`mousedown\` and \`click\` propagation on the dialog body. \`mousedown\` only fires once per click, on a single target — either the backdrop (deliberate dismiss) or the inner dialog (stopped). A drag that starts inside the dialog never produces a \`mousedown\` on the backdrop regardless of where it ends, so the selection is preserved.

## Testing

Manual: open the rename dialog, click and drag from inside the input to outside the dialog, release. Dialog should remain open with the selection intact. Click on the empty backdrop without dragging — dialog dismisses normally.

\`cargo fmt --check\` clean, \`cargo clippy --all-targets -- -D warnings\` clean, \`cargo test -p delta-ui\` green (117 tests, no new), \`cargo check --target wasm32-unknown-unknown\` green.

Closes #26

[AI-assisted - Claude]